### PR TITLE
Adds support for libvirt rbd volume backend #3285

### DIFF
--- a/lib/fog/libvirt/models/compute/templates/ceph.conf
+++ b/lib/fog/libvirt/models/compute/templates/ceph.conf
@@ -1,0 +1,5 @@
+monitor=192.168.100.50,192.168.100.51,192.168.100.52
+port=6789
+libvirt_ceph_pool=foreman-images
+auth_username=foreman
+auth_uuid=8e1050ae-a53c-4280-bc48-8abe0eebafb1

--- a/lib/fog/libvirt/models/compute/templates/server.xml.erb
+++ b/lib/fog/libvirt/models/compute/templates/server.xml.erb
@@ -15,13 +15,35 @@
   </features>
   <clock offset='utc'/>
   <devices>
-<% volumes.each do |vol| -%>
-    <disk type='file' device='disk'>
-      <driver name='qemu' type='<%= vol.format_type %>'/>
-      <source file='<%= vol.path %>'/>
-      <%# we need to ensure a unique target dev -%>
-      <target dev='vd<%= ('a'..'z').to_a[volumes.index(vol)] %>' bus='virtio'/>
-    </disk>
+ <% volumes.each do |vol| -%>
+    <% args = {}
+            File.readlines('ceph.conf').each do |line|
+                pair = line.strip.split("=")
+                key = pair[0]
+                value = pair[1]
+                args[key] = value
+            end
+        %>
+    <% if vol.pool_name.include? args["libvirt_ceph_pool"]  %>
+        <disk type='network' device='disk'>
+            <source protocol='rbd' name='<%= vol.path %>'>
+                <% args["monitor"].split(",").each do |mon| %>
+                    <host name='<%= mon %>' port='<%= args["port"] %>'/>
+                <% end %>
+            </source>
+            <auth username='<%= args["auth_username"] %>'>
+                <secret type='ceph' uuid='<%= args["auth_uuid"] %>'/>
+            </auth>
+            <target dev='vd<%= ('a'..'z').to_a[volumes.index(vol)] %>' bus='virtio'/>
+        </disk>
+    <% else %>
+        <disk type='file' device='disk'>
+         <driver name='qemu' type='<%= vol.format_type %>'/>
+         <source file='<%= vol.path  %>'/>
+         <%# we need to ensure a unique target dev -%>
+         <target dev='vd<%= ('a'..'z').to_a[volumes.index(vol)] %>' bus='virtio'/>
+      </disk>
+    <% end %>
 <% end -%>
 <% if iso_file -%>
     <disk type='file' device='cdrom'>


### PR DESCRIPTION
Uses a file "ceph.conf" to get CEPH cluster info and decide if it is RBD disk instead of a file one.

Still need to figure out how to pass this info instead of reading this file...

Help please!?
