### PR TITLE
Set iso_dir from image path in user-data ISO upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ sudo: required
 before_install:
  - sudo apt-get update -qq
  - sudo apt-get install -y libvirt-dev
+ - gem update bundler
 
 script: bundle exec rake
 

--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -246,6 +246,7 @@ module Fog
             vol = service.volumes.create(:name => cloud_init_volume_name, :capacity => "#{File.size(iso)}b", :allocation => "0G")
             vol.upload_image(iso)
             @iso_file = cloud_init_volume_name
+            @iso_dir = File.dirname(vol.path) if vol.path
           end
         end
 

--- a/minitests/server/user_data_iso_test.rb
+++ b/minitests/server/user_data_iso_test.rb
@@ -61,6 +61,17 @@ class UserDataIsoTest < Minitest::Test
     assert_equal @server.cloud_init_volume_name, @server.iso_file
   end
 
+  def test_iso_dir_is_set_during_user_data_iso_generation
+    @server.stubs(:system).returns(true)
+    volume = @compute.volumes.new
+    volume.stubs(:path).returns("/srv/libvirt/#{@server.cloud_init_volume_name}")
+    Fog::Compute::Libvirt::Volumes.any_instance.stubs(:create).returns(volume)
+    Fog::Compute::Libvirt::Volume.any_instance.stubs(:upload_image)
+
+    @server.create_user_data_iso
+    assert_equal '/srv/libvirt', @server.iso_dir
+  end
+
   def in_a_temp_dir
     Dir.mktmpdir('test-dir') do |d|
       yield d


### PR DESCRIPTION
When the default pool is configured to a location other than
/var/lib/libvirt/images, the iso_dir is now set to the uploaded location of the
user-data image rather than defaulting to default_iso_dir.