### PR TITLE
image_upload: Always return the number of bytes read

### DIFF
--- a/lib/fog/libvirt/requests/compute/upload_volume.rb
+++ b/lib/fog/libvirt/requests/compute/upload_volume.rb
@@ -11,7 +11,7 @@ module Fog
           stream.sendall do |_opaque, n|
             begin
               r = image_file.read(n)
-              [r.length < n ? 0 : r.length, r]
+              r ? [r.length, r] : [0, ""]
             rescue Exception => e
               [-1, ""]
             end


### PR DESCRIPTION
Currently volume uploads end up empty since ruby-libvirt returns the
value passed in from the block

    https://www.redhat.com/archives/libvir-list/2016-June/msg00678.html

Since this is zero libvirtd assumes the upload is finished before it
even started.

We can work around this by returning the string length. This will
continue to work with fixed ruby-libvirt since errors are indicated with
negative values.