### PR TITLE
Update ruby-libvirt dependency.

### DIFF
--- a/fog-libvirt.gemspec
+++ b/fog-libvirt.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency("fog-core", "~> 1.27", ">= 1.27.4")
   s.add_dependency("fog-json")
   s.add_dependency("fog-xml", "~> 0.1.1")
-  s.add_dependency('ruby-libvirt','>= 0.5.0', '< 0.7.0')
+  s.add_dependency('ruby-libvirt','>= 0.7.0')
   s.add_dependency('mime-types','< 2.0') if RUBY_VERSION < '1.9'
   s.add_dependency('nokogiri', '< 1.6') if RUBY_VERSION < '1.9'
   s.add_dependency('octokit', '< 3.0') if RUBY_VERSION < '1.9'


### PR DESCRIPTION
ruby-libvirt 0.7.0 is required to correctly retrieve VM IP address using libvirt (21d1b71cc2533fa5892a1a0bba9147ab2e2dca72).

This should finally resolve the #16 