### PR TITLE
Support older libvirt address retrieval

### DIFF
--- a/lib/fog/libvirt/compute.rb
+++ b/lib/fog/libvirt/compute.rb
@@ -45,6 +45,7 @@ module Fog
       request :destroy_interface
       request :get_node_info
       request :update_display
+      request :libversion
 
       module Shared
         include Fog::Compute::LibvirtUtil
@@ -57,11 +58,11 @@ module Fog
           require 'libvirt'
         end
 
+        private
+
         def client
           return @client if defined?(@client)
         end
-
-        private
 
         #read mocks xml
         def read_xml(file_name)

--- a/lib/fog/libvirt/compute.rb
+++ b/lib/fog/libvirt/compute.rb
@@ -57,11 +57,11 @@ module Fog
           require 'libvirt'
         end
 
-        private
-
         def client
           return @client if defined?(@client)
         end
+
+        private
 
         #read mocks xml
         def read_xml(file_name)

--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -278,7 +278,7 @@ module Fog
 
           # if ruby-libvirt not compiled with support, or remote library is
           # too old (must be newer than 1.2.8), then use old fallback
-          if not has_dhcp_leases or service.client.libversion < 1002008
+          if not has_dhcp_leases or service.libversion() < 1002008
             addresses_method = self.method(:addresses_ip_command)
           end
 

--- a/lib/fog/libvirt/requests/compute/libversion.rb
+++ b/lib/fog/libvirt/requests/compute/libversion.rb
@@ -1,0 +1,18 @@
+
+module Fog
+  module Compute
+    class Libvirt
+      class Real
+        def libversion()
+          client.libversion
+        end
+      end
+
+      class Mock
+        def libversion()
+          return 1002009
+        end
+      end
+    end
+  end
+end

--- a/minitests/server/server_test.rb
+++ b/minitests/server/server_test.rb
@@ -7,40 +7,31 @@ class ServerTest < Minitest::Test
   end
 
   def test_addresses_calls_compat_version_for_no_dhcp_leases_support
-    mocked_client = MiniTest::Mock.new
     network = Libvirt::Network.new
-    @compute.stubs(:client).returns(mocked_client)
     @compute.expects(:networks).returns([network])
     network.expects(:dhcp_leases).raises(NoMethodError)
     @server.expects(:addresses_ip_command).returns(true)
 
     @server.send(:addresses)
-    mocked_client.verify
   end
 
   def test_addresses_calls_compat_version_for_older_libvirt
-    mocked_client = MiniTest::Mock.new
     network = Libvirt::Network.new
-    @compute.stubs(:client).returns(mocked_client)
+    @compute.expects(:libversion).returns(1002007)
     @compute.expects(:networks).returns([network])
     network.expects(:dhcp_leases).returns(true)
-    mocked_client.expect(:libversion, 1002007)
     @server.expects(:addresses_ip_command).returns(true)
 
     @server.send(:addresses)
-    mocked_client.verify
   end
 
   def test_addresses_calls_compat_version_for_newer_libvirt
-    mocked_client = MiniTest::Mock.new
     network = Libvirt::Network.new
-    @compute.stubs(:client).returns(mocked_client)
+    @compute.expects(:libversion).returns(1002008)
     @compute.expects(:networks).returns([network])
     network.expects(:dhcp_leases).returns(true)
-    mocked_client.expect(:libversion, 1002008)
     @server.expects(:addresses_dhcp).returns(true)
 
     @server.send(:addresses)
-    mocked_client.verify
   end
 end

--- a/minitests/server/server_test.rb
+++ b/minitests/server/server_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+
+class ServerTest < Minitest::Test
+  def setup
+    @compute = Fog::Compute[:libvirt]
+    @server = @compute.servers.new(:name => "test")
+  end
+
+  def test_addresses_calls_compat_version_for_no_dhcp_leases_support
+    mocked_client = MiniTest::Mock.new
+    network = Libvirt::Network.new
+    @compute.stubs(:client).returns(mocked_client)
+    @compute.expects(:networks).returns([network])
+    network.expects(:dhcp_leases).raises(NoMethodError)
+    @server.expects(:addresses_ip_command).returns(true)
+
+    @server.send(:addresses)
+    mocked_client.verify
+  end
+
+  def test_addresses_calls_compat_version_for_older_libvirt
+    mocked_client = MiniTest::Mock.new
+    network = Libvirt::Network.new
+    @compute.stubs(:client).returns(mocked_client)
+    @compute.expects(:networks).returns([network])
+    network.expects(:dhcp_leases).returns(true)
+    mocked_client.expect(:libversion, 1002007)
+    @server.expects(:addresses_ip_command).returns(true)
+
+    @server.send(:addresses)
+    mocked_client.verify
+  end
+
+  def test_addresses_calls_compat_version_for_newer_libvirt
+    mocked_client = MiniTest::Mock.new
+    network = Libvirt::Network.new
+    @compute.stubs(:client).returns(mocked_client)
+    @compute.expects(:networks).returns([network])
+    network.expects(:dhcp_leases).returns(true)
+    mocked_client.expect(:libversion, 1002008)
+    @server.expects(:addresses_dhcp).returns(true)
+
+    @server.send(:addresses)
+    mocked_client.verify
+  end
+end

--- a/tests/libvirt/models/compute/server_tests.rb
+++ b/tests/libvirt/models/compute/server_tests.rb
@@ -21,17 +21,7 @@ Shindo.tests('Fog::Compute[:libvirt] | server model', ['libvirt']) do
       end
     end
     tests('have an ip_address action that') do
-      test('returns the latest IP address lease') {
-        server.service.instance_variable_set(:@client,
-          Class.new do
-            attr_accessor :libversion
-            def libversion
-              @libversion || 1002009
-            end
-          end.new
-        )
-        server.public_ip_address() == '1.2.5.6'
-      }
+      test('returns the latest IP address lease') { server.public_ip_address() == '1.2.5.6' }
     end
     tests('have attributes') do
       model_attribute_hash = server.attributes

--- a/tests/libvirt/models/compute/server_tests.rb
+++ b/tests/libvirt/models/compute/server_tests.rb
@@ -21,7 +21,17 @@ Shindo.tests('Fog::Compute[:libvirt] | server model', ['libvirt']) do
       end
     end
     tests('have an ip_address action that') do
-      test('returns the latest IP address lease') { server.public_ip_address() == '1.2.5.6' }
+      test('returns the latest IP address lease') {
+        server.service.instance_variable_set(:@client,
+          Class.new do
+            attr_accessor :libversion
+            def libversion
+              @libversion || 1002009
+            end
+          end.new
+        )
+        server.public_ip_address() == '1.2.5.6'
+      }
     end
     tests('have attributes') do
       model_attribute_hash = server.attributes


### PR DESCRIPTION
Libvirt releases before 1.2.8 do not fully support the
virNetworkGetDHCPLeases used by dhcp_leases, so provide a compatibility
check to determine the version of the library in order to determine
which method to use to retrieve the mac address and then replace the
current addresses method reference with this.

Currently uses calling 'virsh verison' and regex comparison of the response to
determine whether to use the previous approach which has been restored
or the more recent method that calls dhcp_leases.

Fixes: #27 
