### PR TITLE
Allow update_display on VMs with non-auto keymap

### DIFF
--- a/lib/fog/libvirt/requests/compute/update_display.rb
+++ b/lib/fog/libvirt/requests/compute/update_display.rb
@@ -4,17 +4,21 @@ module Fog
       class Real
         def update_display(options = { })
           raise ArgumentError, "uuid is a required parameter" unless options.key? :uuid
+
+          domain = client.lookup_domain_by_uuid(options[:uuid])
+
           display          = { }
           display[:type]   = options[:type] || 'vnc'
           display[:port]   = (options[:port] || -1).to_s
           display[:listen] = options[:listen].to_s   if options[:listen]
           display[:passwd] = options[:password].to_s if options[:password]
           display[:autoport] = 'yes' if display[:port] == '-1'
+          display[:keymap] = options[:keymap] || xml_elements(domain.xml_desc, "graphics", "keymap")
 
           builder = Nokogiri::XML::Builder.new { graphics_ (display) }
           xml     = Nokogiri::XML(builder.to_xml).root.to_s
 
-          client.lookup_domain_by_uuid(options[:uuid]).update_device(xml, 0)
+          domain.update_device(xml, 0)
           # if we got no exceptions, then we're good'
           true
         end


### PR DESCRIPTION
If the vnc keymap has been changed from auto to, for example, en-us,
calling update_display will fail with a "Call to
virDomainUpdateDeviceFlags failed: internal error cannot change keymap
setting on vnc graphics" error. This commit changes it so that if no
keymap has been passed explicitly in the options we will use the keymap
that is currently used.