### PR TITLE
Fix breaking CI on older versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
     - rvm: 1.8.7
       gemfile: gemfiles/Gemfile-ruby-1.8.7
     - rvm: 1.9.3
-      gemfile: Gemfile
+      gemfile: gemfiles/Gemfile-ruby-1.9.3
     - rvm: 2.0.0
       gemfile: Gemfile
     - rvm: 2.1.0

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -21,3 +21,4 @@
 * Steve Smith <github@scsworld.co.uk>
 * Vincent Demeester <vincent+git@demeester.fr>
 * Wesley Beary <geemus@gmail.com>
+* Tomer Brisker <tbrisker@redhat.com>

--- a/gemfiles/Gemfile-ruby-1.9.3
+++ b/gemfiles/Gemfile-ruby-1.9.3
@@ -2,11 +2,8 @@ source "https://rubygems.org"
 
 group :development, :test do
   # This is here because gemspec doesn't support require: false
-  gem 'coveralls', :require => false
   gem "netrc", :require => false
-  gem "octokit", '~> 2.7.2', :require => false
-  gem 'rake', '~> 10.1.0'
-  gem 'term-ansicolor', '< 1.4'
+  gem "octokit", '<= 4.3', :require => false
 end
 
 gemspec :path => "../"


### PR DESCRIPTION
Pin some dependencies so that travis can run on older ruby versions.