### PR TITLE
Skip over networks that no longer exist

### DIFF
--- a/lib/fog/libvirt/requests/compute/list_networks.rb
+++ b/lib/fog/libvirt/requests/compute/list_networks.rb
@@ -6,7 +6,15 @@ module Fog
           data=[]
           if filter.keys.empty?
             (client.list_networks + client.list_defined_networks).each do |network_name|
-              data << network_to_attributes(client.lookup_network_by_name(network_name))
+              begin
+                data << network_to_attributes(client.lookup_network_by_name(network_name))
+              rescue => error
+                if error.message =~ /Network not found/
+                  next # Network no longer exists, skip over and carry on.
+                else
+                  raise error
+                end
+              end
             end
           else
             data = [network_to_attributes(get_network_by_filter(filter))]


### PR DESCRIPTION
If a user is running multiple libvirt clients concurrently it's possible to get into a situation where `list_networks.rb` will attempt to lookup a network that has been removed by another client. We hit this scenario ourselves today as we are rapidly creating and destroying both domains and virtual networks for testing purposes. This PR will simply skip over any networks that no longer exist but will still raise an exception for any other errors returned when attempting to lookup networks.