### PR TITLE
libvirt template: Add hugepages support

### DIFF
--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -28,6 +28,7 @@ module Fog
         attribute :boot_order
         attribute :display
         attribute :cpu
+        attribute :hugepages
 
         attribute :state
 

--- a/lib/fog/libvirt/models/compute/templates/server.xml.erb
+++ b/lib/fog/libvirt/models/compute/templates/server.xml.erb
@@ -1,6 +1,11 @@
 <domain type='<%= domain_type %>'>
   <name><%= name %></name>
   <memory><%= memory_size %></memory>
+<% if !hugepages.empty? -%>
+  <memoryBacking>
+    <hugepages/>
+  </memoryBacking>
+<% end -%>
   <vcpu><%= cpus %></vcpu>
   <os>
     <type arch='<%= arch %>'><%= os_type %></type>


### PR DESCRIPTION
Hi there guys;

While checking issue #6, I thought that this PR would fix it.
Notice that the code is untested: Used commit bdccac71 as a template.

If the attribute 'hugepages' is set to any value, then define the guest as
having its memory backed by a hugepages pool.
Resolves: fog/fog-libvirt#6