### PR TITLE
Volume#clone_volume supports different pools

### DIFF
--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -434,7 +434,7 @@ module Fog
             template_volume = service.volumes.all(:name => volume_template_name).first
             raise Fog::Errors::Error.new("Template #{volume_template_name} not found") unless template_volume
             begin
-              volume = template_volume.clone("#{options[:name]}")
+              volume = template_volume.clone_volume("#{options[:name]}")
             rescue => e
               raise Fog::Errors::Error.new("Error creating the volume : #{e}")
             end

--- a/lib/fog/libvirt/models/compute/volume.rb
+++ b/lib/fog/libvirt/models/compute/volume.rb
@@ -62,14 +62,15 @@ module Fog
           new_volume.reload
         end
 
-        def clone_volume(new_name)
+        def clone_volume(new_name, new_pool_name=nil)
           requires :pool_name
 
-          new_volume      = self.dup
-          new_volume.key  = nil
-          new_volume.name = new_name
-          new_volume.path = service.clone_volume(pool_name, new_volume.to_xml, self.name).path
-          new_volume.id   = new_volume.path
+          new_pool_name      ||= pool_name
+          new_volume           = self.dup
+          new_volume.key       = nil
+          new_volume.name      = new_name
+          new_volume.path      = service.clone_volume(pool_name, new_pool_name, new_volume.to_xml, self.name).path
+          new_volume.id        = new_volume.path
 
           new_volume.reload
         end

--- a/lib/fog/libvirt/models/compute/volume.rb
+++ b/lib/fog/libvirt/models/compute/volume.rb
@@ -69,6 +69,7 @@ module Fog
           new_volume.key  = nil
           new_volume.name = new_name
           new_volume.path = service.clone_volume(pool_name, new_volume.to_xml, self.name).path
+          new_volume.id   = new_volume.path
 
           new_volume.reload
         end

--- a/lib/fog/libvirt/requests/compute/clone_volume.rb
+++ b/lib/fog/libvirt/requests/compute/clone_volume.rb
@@ -10,7 +10,10 @@ module Fog
 
       class Mock
         def clone_volume(pool_name, new_pool_name, xml, name)
-          Fog::Compute::Libvirt::Volume.new({:pool_name => new_pool_name, :xml => xml})
+          Fog::Compute::Libvirt::Volume.new({:pool_name => new_pool_name,
+                                             :xml => xml,
+                                             :name => name,
+                                             :path => [new_pool_name, name, 'path'].join('.')})
         end
       end
     end

--- a/lib/fog/libvirt/requests/compute/clone_volume.rb
+++ b/lib/fog/libvirt/requests/compute/clone_volume.rb
@@ -2,15 +2,15 @@ module Fog
   module Libvirt
     class Compute
       class Real
-        def clone_volume (pool_name, xml, name)
+        def clone_volume (pool_name, new_pool_name, xml, name)
           vol = client.lookup_storage_pool_by_name(pool_name).lookup_volume_by_name(name)
-          client.lookup_storage_pool_by_name(pool_name).create_vol_xml_from(xml, vol)
+          client.lookup_storage_pool_by_name(new_pool_name).create_vol_xml_from(xml, vol)
         end
       end
 
       class Mock
-        def clone_volume(pool_name, xml, name)
-          Fog::Libvirt::Compute::Volume.new({:pool_name => pool_name, :xml => xml})
+        def clone_volume(pool_name, new_pool_name, xml, name)
+          Fog::Compute::Libvirt::Volume.new({:pool_name => new_pool_name, :xml => xml})
         end
       end
     end


### PR DESCRIPTION
Volume#clone_volume supports duplicate the volume.
However, We have two different pools, we can't clone volume directory.
So I added an option for specifying the pool name to `Volume#clone_volume`.