### PR TITLE
Test the ip_command functions success path

### DIFF
--- a/fog-libvirt.gemspec
+++ b/fog-libvirt.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |s|
   s.add_dependency('ruby-libvirt','>= 0.7.0')
   s.add_dependency("json")
 
+  s.add_development_dependency("net-ssh")
   s.add_development_dependency("minitest", "~> 5.0")
   s.add_development_dependency("minitest-stub-const")
   s.add_development_dependency("pry")

--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -290,8 +290,7 @@ module Fog
           addresses(service_arg, options)
         end
 
-        def ssh_ip_command(command, uri = {})
-
+        def ssh_ip_command(ip_command, uri)
           # Retrieve the parts we need from the service to setup our ssh options
           user=uri.user #could be nil
           host=uri.host
@@ -321,7 +320,7 @@ module Fog
           end
         end
 
-        def local_ip_command(command)
+        def local_ip_command(ip_command)
           # Execute the ip_command locally
           # Initialize empty ip_address string
           ip_address=""

--- a/minitests/server/server_test.rb
+++ b/minitests/server/server_test.rb
@@ -34,4 +34,34 @@ class ServerTest < Minitest::Test
 
     @server.send(:addresses)
   end
+
+  def test_ssh_ip_command_success
+    fog_ssh = MiniTest::Mock.new
+    result = MiniTest::Mock.new
+    result.expect(:status, 0)
+    result.expect(:stdout, "any_ip")
+    fog_ssh.expect(:run, [result], [String])
+    uri = ::Fog::Compute::LibvirtUtil::URI.new('qemu+ssh://localhost:22?keyfile=nofile')
+    Fog::SSH.stub(:new, fog_ssh) do
+      @server.send(:ssh_ip_command, "test command", uri)
+    end
+    fog_ssh.verify
+  end
+
+  def test_local_ip_command_success
+    proc_info = lambda do |p|
+      assert_equal "test command", p
+    end
+    output = MiniTest::Mock.new
+    output.expect(:each_line, "127.0.0.1")
+    output.expect(:pid, 0)
+    status = MiniTest::Mock.new
+    status.expect(:exitstatus, 0)
+    Process.stubs(:waitpid2).returns([0, status])
+    IO.stub(:popen, proc_info, output) do
+      @server.send(:local_ip_command, "test command")
+    end
+    output.verify
+    status.verify
+  end
 end


### PR DESCRIPTION
Add tests to call the ssh_ip_command and local_ip_command to ensure
that variables are reference correctly and any required dependenencies
are in place.

Include missing test dependency net::ssh, but leave it optional.

Fixes issue introduced in #29 