### PR TITLE
Add qemu-guest-agent channel.

### DIFF
--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -29,6 +29,7 @@ module Fog
         attribute :display
         attribute :cpu
         attribute :hugepages
+        attribute :guest_agent
 
         attribute :state
 
@@ -480,6 +481,7 @@ module Fog
             :display                => default_display,
             :cpu                    => {},
             :hugepages              => false,
+            :guest_agent            => true,
           }
         end
 

--- a/lib/fog/libvirt/models/compute/templates/server.xml.erb
+++ b/lib/fog/libvirt/models/compute/templates/server.xml.erb
@@ -60,9 +60,11 @@
       <model type='<%= nic.model %>'/>
     </interface>
 <% end -%>
+<% if guest_agent -%>
     <channel type='unix'>
       <target type='virtio' name='org.qemu.guest_agent.0'/>
     </channel>
+<% end -%>
     <serial type='pty'>
       <target port='0'/>
     </serial>

--- a/lib/fog/libvirt/models/compute/templates/server.xml.erb
+++ b/lib/fog/libvirt/models/compute/templates/server.xml.erb
@@ -60,6 +60,9 @@
       <model type='<%= nic.model %>'/>
     </interface>
 <% end -%>
+    <channel type='unix'>
+      <target type='virtio' name='org.qemu.guest_agent.0'/>
+    </channel>
     <serial type='pty'>
       <target port='0'/>
     </serial>


### PR DESCRIPTION
Fixes #55.

This adds a `qemu-guest-agent` channel. 
It allows to instruct the VM from the hypervisor e.g. to freeze filesystems for snapshotting. 
With RHEL 7 / CentOS 7, if the agent channel is present, anaconda installs and activates the guest agent automatically. 

People might want to configure this (on / off), but I would vote to have this on by default 