### PR TITLE
Allow to specify UID and GID of volume.

### DIFF
--- a/lib/fog/libvirt/models/compute/templates/volume.xml.erb
+++ b/lib/fog/libvirt/models/compute/templates/volume.xml.erb
@@ -5,8 +5,8 @@
         <target>
           <format type="<%= format_type %>"/>
           <permissions>
-            <owner>0</owner>
-            <group>0</group>
+            <owner><%= owner %></owner>
+            <group><%= group %></group>
             <mode>0744</mode>
             <label>virt_image_t</label>
           </permissions>
@@ -16,8 +16,8 @@
           <path><%= backing_volume.path %></path>
           <format type="<%= backing_volume.format_type %>"/>
           <permissions>
-            <owner>0</owner>
-            <group>0</group>
+            <owner><%= owner %></owner>
+            <group><%= group %></group>
             <mode>0744</mode>
             <label>virt_image_t</label>
           </permissions>

--- a/lib/fog/libvirt/models/compute/volume.rb
+++ b/lib/fog/libvirt/models/compute/volume.rb
@@ -16,6 +16,8 @@ module Fog
         attribute :path
         attribute :capacity
         attribute :allocation
+        attribute :owner
+        attribute :group
         attribute :format_type
         attribute :backing_volume
 
@@ -106,6 +108,8 @@ module Fog
             :name        => randomized_name,
             :capacity    => "10G",
             :allocation  => "1G",
+            :owner       => "0",
+            :group       => "0",
           }
         end
 


### PR DESCRIPTION
This would allow to remove some duplicated code in vagrant-libvirt/vagrant-libvirt/pull/868