### PR TITLE
libvirt template: Add hugepages support

### DIFF
--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -28,6 +28,7 @@ module Fog
         attribute :boot_order
         attribute :display
         attribute :cpu
+        attribute :hugepages
 
         attribute :state
 
@@ -477,7 +478,8 @@ module Fog
             :network_bridge_name    => "br0",
             :boot_order             => %w[hd cdrom network],
             :display                => default_display,
-            :cpu                    => {}
+            :cpu                    => {},
+            :hugepages              => false,
           }
         end
 

--- a/lib/fog/libvirt/models/compute/templates/server.xml.erb
+++ b/lib/fog/libvirt/models/compute/templates/server.xml.erb
@@ -1,6 +1,11 @@
 <domain type='<%= domain_type %>'>
   <name><%= name %></name>
   <memory><%= memory_size %></memory>
+<% if hugepages -%>
+  <memoryBacking>
+    <hugepages/>
+  </memoryBacking>
+<% end -%>
   <vcpu><%= cpus %></vcpu>
   <os>
     <type arch='<%= arch %>'><%= os_type %></type>

--- a/tests/libvirt/models/compute/server_tests.rb
+++ b/tests/libvirt/models/compute/server_tests.rb
@@ -42,6 +42,7 @@ Shindo.tests('Fog::Compute[:libvirt] | server model', ['libvirt']) do
         :volumes,
         :active,
         :boot_order,
+        :hugepages,
         :state]
       tests("The server model should respond to") do
         attributes.each do |attribute|


### PR DESCRIPTION
If the attribute 'hugepages' is set to true, define the guest as
having its memory backed by a hugepages pool.
    
closes GH-6
