### PR TITLE
fog-libvirt.gemspec: remove version constraint on fog-xml

### DIFF
--- a/fog-libvirt.gemspec
+++ b/fog-libvirt.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency("fog-core", ">= 1.27.4")
   s.add_dependency("fog-json")
-  s.add_dependency("fog-xml", "~> 0.1.1")
+  s.add_dependency("fog-xml", "~> 0.1")
   s.add_dependency('ruby-libvirt','>= 0.7.0')
   s.add_dependency("json")
 


### PR DESCRIPTION
Based on the discussion in #59, remove the version constraint on fog-xml.

Please ignore the branch name, this does not remove the dependency, only the version constraint.