### PR TITLE
Support VirtIO for ceph RBD disks

### DIFF
--- a/lib/fog/libvirt/models/compute/README.md
+++ b/lib/fog/libvirt/models/compute/README.md
@@ -35,9 +35,12 @@ port=6789
 libvirt_ceph_pool=rbd_pool_name
 auth_username=libvirt
 auth_uuid=uuid_of_libvirt_secret
+bus_type=virtio
 ```
 For more recent versions of libvirt which support using the secret by name (`usage` attribute in the `secret` tag),
 you can also drop `auth_uuid` and specify `auth_usage` instead. If both are specified, `auth_uuid` will be preferred for maximum compatibility.
+
+The `bus_type` can be set to `virtio` or `scsi`. If it is ommited, the default is `scsi`.
 
 ## Configuration
 

--- a/lib/fog/libvirt/models/compute/templates/server.xml.erb
+++ b/lib/fog/libvirt/models/compute/templates/server.xml.erb
@@ -63,7 +63,11 @@
         <secret type='ceph' usage='<%= args["auth_usage"] %>'/>
        <% end -%>
       </auth>
-      <target dev='sd<%= ('a'..'z').to_a[volumes.index(vol)] %>' bus='scsi'/>
+      <% if args['bus_type'] == 'virtio' %>
+        <target dev='vd<%= ('a'..'z').to_a[volumes.index(vol)] %>' bus='virtio'/>
+      <% else %>
+        <target dev='sd<%= ('a'..'z').to_a[volumes.index(vol)] %>' bus='scsi'/>
+      <% end %>
     </disk>
   <% else %>
     <disk type='file' device='disk'>


### PR DESCRIPTION
During testing I discovered that my VM can freez with heavy disk load.
I also saw the following error in the libvirt/qemu log file:

  lsi_scsi: error: ORDERED queue not implemented

It appears that the SCSI driver is not very well tested or widely used
since this problem has also been seen by others roughly 9 years ago. The
suggestion back then on the "kvm" mailing list was to just use VirtIO
because it is better maintained:

  https://kvm.vger.kernel.narkive.com/gh8t5TeK/virtual-scsi-disks-hangs-on-heavy-io

Signed-off-by: Florian Pritz <bluewind@xinu.at>


NOTE: I have not actually tested this patch in a deployed system, but I did test the if line in `irb`.