### PR TITLE
Add support for virtio-rng.

### DIFF
--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -483,7 +483,7 @@ module Fog
             :cpu                    => {},
             :hugepages              => false,
             :guest_agent            => true,
-            :virtio_rng             => true,
+            :virtio_rng             => {},
           }
         end
 

--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -30,6 +30,7 @@ module Fog
         attribute :cpu
         attribute :hugepages
         attribute :guest_agent
+        attribute :virtio_rng
 
         attribute :state
 
@@ -482,6 +483,7 @@ module Fog
             :cpu                    => {},
             :hugepages              => false,
             :guest_agent            => true,
+            :virtio_rng             => true,
           }
         end
 

--- a/lib/fog/libvirt/models/compute/templates/server.xml.erb
+++ b/lib/fog/libvirt/models/compute/templates/server.xml.erb
@@ -94,11 +94,16 @@
       <target type='virtio' name='org.qemu.guest_agent.0'/>
     </channel>
 <% end -%>
-<% if virtio_rng -%>
     <rng model='virtio'>
-      <backend model='random'/>
-    </rng>
+<%
+  rng_backend_model = virtio_rng[:backend_model] ? virtio_rng[:backend_model] : 'random'
+-%>
+<% if virtio_rng[:backend_path] -%>
+      <backend model='<%= rng_backend_model %>'><%= virtio_rng[:backend_path] %></backend>
+<% else -%>
+      <backend model='<%= rng_backend_model %>'/>
 <% end -%>
+    </rng>
     <serial type='pty'>
       <target port='0'/>
     </serial>

--- a/lib/fog/libvirt/models/compute/templates/server.xml.erb
+++ b/lib/fog/libvirt/models/compute/templates/server.xml.erb
@@ -94,6 +94,11 @@
       <target type='virtio' name='org.qemu.guest_agent.0'/>
     </channel>
 <% end -%>
+<% if virtio_rng -%>
+    <rng model='virtio'>
+      <backend model='random'/>
+    </rng>
+<% end -%>
     <serial type='pty'>
       <target port='0'/>
     </serial>


### PR DESCRIPTION
This allows to push entropy from the KVM host into the VM. 
It is supported since many years and happens in-kernel without any need for configuration. Since gathering good entropy inside VMs is hard without this support, this strongly improves security and performance of encrypted connections. 