### PR TITLE
Being able to create cloud-init iso using mkisofs

### DIFF
--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -32,7 +32,7 @@ module Fog
         attribute :hugepages
         attribute :guest_agent
         attribute :virtio_rng
-
+        attribute :geniso_util
         attribute :state
 
         # The following attributes are only needed when creating a new vm
@@ -241,12 +241,7 @@ module Fog
 
           isofile = Tempfile.new(['init', '.iso']).path
 
-          geniso_util = case
-          when command_exists?('genisoimage')
-            'genisoimage'
-          when command_exists?('mkisofs')
-            'mkisofs'
-          else
+          unless %w{genisoimage mkisofs}.include?(geniso_util)
             raise Fog::Errors::Error.new("genisoimage/mkisofs is required for generate cloud-init iso disk.")
           end
 
@@ -495,6 +490,7 @@ module Fog
             :hugepages              => false,
             :guest_agent            => true,
             :virtio_rng             => {},
+            :geniso_util            => 'genisoimage'
           }
         end
 
@@ -509,11 +505,6 @@ module Fog
 
         def default_display
           {:port => '-1', :listen => '127.0.0.1', :type => 'vnc', :password => '' }
-        end
-
-        def command_exists?(name)
-          `which #{name}`
-          $?.success?
         end
       end
     end

--- a/minitests/server/user_data_iso_test.rb
+++ b/minitests/server/user_data_iso_test.rb
@@ -26,7 +26,7 @@ class UserDataIsoTest < Minitest::Test
 
   def test_iso_is_generated
     in_a_temp_dir do |d|
-      @server.expects(:system).with(regexp_matches(/^(genisoimage|mkisofs)/)).returns(true)
+      @server.expects(:system).with(regexp_matches(/^genisoimage/)).returns(true)
       @server.generate_config_iso_in_dir(d, @test_data) {|iso| }
     end
   end

--- a/minitests/server/user_data_iso_test.rb
+++ b/minitests/server/user_data_iso_test.rb
@@ -26,7 +26,7 @@ class UserDataIsoTest < Minitest::Test
 
   def test_iso_is_generated
     in_a_temp_dir do |d|
-      @server.expects(:system).with(regexp_matches(/^genisoimage/)).returns(true)
+      @server.expects(:system).with(regexp_matches(/^(genisoimage|mkisofs)/)).returns(true)
       @server.generate_config_iso_in_dir(d, @test_data) {|iso| }
     end
   end


### PR DESCRIPTION
MacOS does not support `genisoimage`. Given the behaviour between `mkisofs` and  `genisoimage` is identical (on CentOS 8 it's mkisofs is even symlinked to genisoimage), it will really be useful to use `mkisofs` as a fallback of `genisoimage`.

Creating domain via cloud-init using mkisofs looks like

```ruby
server = fog.servers.create(
  name: domain_name,
  cpus: 1,
  memory_size: 2048 * 1024,
  domain_type: 'kvm',
  os_type: 'hvm',
  network_nat_network: 'vm-network',
  volumes: [ new_volume ],
  user_data: user_data,
  geniso_util: 'mkisofs',
)
```