### PR TITLE
Update video card in server.xml.erb

### DIFF
--- a/lib/fog/libvirt/models/compute/templates/server.xml.erb
+++ b/lib/fog/libvirt/models/compute/templates/server.xml.erb
@@ -137,7 +137,7 @@ end
 -%>
     <graphics type='<%= display_type %>' port='<%= display_port %>' autoport='<%= autoport %>' <%= display_listen %> <%= display_password %> />
     <video>
-      <model type='cirrus' vram='9216' heads='1'/>
+      <model type='qxl' ram='65536' vram='65536' vgamem='16384' heads='1'/>
     </video>
   </devices>
 </domain>


### PR DESCRIPTION
Changing video card from ``<model type='cirrus' vram='9216' heads='1'/>`` to ``<model type='qxl' ram='65536' vram='65536' vgamem='16384' heads='1'/>`` as 'cirrus-vga' is deprecated.
This change removes the warning message "qemu-kvm: -device cirrus-vga,id=video0,bus=pci.0,addr=0x2: warning: 'cirrus-vga' is deprecated, please use a different VGA card instead" found in the libvirt logs when starting a VM.