### PR TITLE
Return empty collection if no matching volume found

### DIFF
--- a/lib/fog/libvirt/models/compute/volume.rb
+++ b/lib/fog/libvirt/models/compute/volume.rb
@@ -60,6 +60,7 @@ module Fog
           new_volume.save
 
           new_volume.reload
+          new_volume
         end
 
         def clone_volume(new_name)
@@ -71,6 +72,7 @@ module Fog
           new_volume.path = service.clone_volume(pool_name, new_volume.to_xml, self.name).path
 
           new_volume.reload
+          new_volume
         end
 
         def upload_image(file_path)

--- a/lib/fog/libvirt/models/compute/volume.rb
+++ b/lib/fog/libvirt/models/compute/volume.rb
@@ -60,7 +60,6 @@ module Fog
           new_volume.save
 
           new_volume.reload
-          new_volume
         end
 
         def clone_volume(new_name)
@@ -72,7 +71,6 @@ module Fog
           new_volume.path = service.clone_volume(pool_name, new_volume.to_xml, self.name).path
 
           new_volume.reload
-          new_volume
         end
 
         def upload_image(file_path)

--- a/lib/fog/libvirt/requests/compute/list_volumes.rb
+++ b/lib/fog/libvirt/requests/compute/list_volumes.rb
@@ -78,15 +78,22 @@ module Fog
         def list_volumes(filters={ })
           vol1 = mock_volume 'vol1'
           vol2 = mock_volume 'vol2'
-          [vol1, vol2]
+          vols = [vol1, vol2]
+
+          if filters.keys.empty?
+            return vols
+          end
+
+          key = filters.keys.first
+          vols.select { |v| v[key] == filters[key] }
         end
 
         def mock_volume name
           {
               :pool_name   => 'vol.pool.name',
               :key         => 'vol.key',
-              :id          => 'vol.key',
-              :path        => 'vol.path',
+              :id          => "vol.#{name}",
+              :path        => "path/to/disk", # used by in mock_files/domain.xml
               :name        => name,
               :format_type => 'raw',
               :allocation  => 123,

--- a/lib/fog/libvirt/requests/compute/list_volumes.rb
+++ b/lib/fog/libvirt/requests/compute/list_volumes.rb
@@ -17,7 +17,7 @@ module Fog
               end
             end
           else
-            return [get_volume(filter)]
+            data << get_volume(filter)
           end
           data.compact
         end
@@ -69,7 +69,8 @@ module Fog
               return raw ? vol : volume_to_attributes(vol)
             end
           end
-          { }
+
+          nil
         end
       end
 

--- a/lib/fog/libvirt/requests/compute/list_volumes.rb
+++ b/lib/fog/libvirt/requests/compute/list_volumes.rb
@@ -91,7 +91,7 @@ module Fog
         def mock_volume name
           {
               :pool_name   => 'vol.pool.name',
-              :key         => 'vol.key',
+              :key         => "vol.#{name}", # needs to match id
               :id          => "vol.#{name}",
               :path        => "path/to/disk", # used by in mock_files/domain.xml
               :name        => name,

--- a/tests/libvirt/models/compute/volumes_tests.rb
+++ b/tests/libvirt/models/compute/volumes_tests.rb
@@ -7,8 +7,9 @@ Shindo.tests('Fog::Compute[:libvirt] | volumes collection', ['libvirt']) do
     test('should be a kind of Fog::Libvirt::Compute::Volumes') { volumes.kind_of? Fog::Libvirt::Compute::Volumes }
     tests('should be able to reload itself').succeeds { volumes.reload }
     tests('should be able to get a model') do
-      tests('by instance uuid').succeeds { volumes.get volumes.first.id }
+      tests('by instance uuid').succeeds { volumes.get volumes.first.key }
     end
+    test('filtered should be empty') { volumes.all(:name => "does-not-exist").empty? }
   end
 
 end

--- a/tests/libvirt/models/compute/volumes_tests.rb
+++ b/tests/libvirt/models/compute/volumes_tests.rb
@@ -7,7 +7,7 @@ Shindo.tests('Fog::Compute[:libvirt] | volumes collection', ['libvirt']) do
     test('should be a kind of Fog::Libvirt::Compute::Volumes') { volumes.kind_of? Fog::Libvirt::Compute::Volumes }
     tests('should be able to reload itself').succeeds { volumes.reload }
     tests('should be able to get a model') do
-      tests('by instance uuid').succeeds { volumes.get volumes.first.key }
+      tests('by instance uuid').succeeds { volumes.get volumes.first.id }
     end
     test('filtered should be empty') { volumes.all(:name => "does-not-exist").empty? }
   end


### PR DESCRIPTION
Change the saving of the return from get_volume to ensure the
resulting list is empty if no volume was found based on the filter
keys specified.

Update the mock to replicate similar behaviour that can be
expected to be relied upon that highlights a small number of
assumptions relying on existing mock behaviour that would not
align with real world experiences.