### PR TITLE
Skip monitor loop if it's not defined in ceph RBD disks

### DIFF
--- a/lib/fog/libvirt/models/compute/templates/server.xml.erb
+++ b/lib/fog/libvirt/models/compute/templates/server.xml.erb
@@ -52,9 +52,11 @@
     <disk type='network' device='disk'>
       <driver name='qemu' type='<%= vol.format_type %>' cache='writeback' discard='unmap'/>
       <source protocol='rbd' name='<%= vol.path %>'>
+      <% if args.key?("monitor") -%>
         <% args["monitor"].split(",").each do |mon| %>
         <host name='<%= mon %>' port='<%= args["port"] %>'/>
         <% end %>
+      <% end %>
       </source>
       <auth username='<%= args["auth_username"] %>'>
        <% if args.key?("auth_uuid") -%>


### PR DESCRIPTION
It's already defined in the pool.
We have multiple ceph clusters in different environments, so we have many monitor groups.
This way we let the configuration manager define the pool with its mons and keep it simple.
The only issue is if you want to name the pool differently per environment and
if you want to have more than a rbd pool per host.