### PR TITLE
Fixes #24 - don't fail if bridge is undefined

### DIFF
--- a/lib/fog/libvirt/requests/compute/list_networks.rb
+++ b/lib/fog/libvirt/requests/compute/list_networks.rb
@@ -25,12 +25,20 @@ module Fog
           end
         end
 
+        # bridge name may not be defined in some networks, we should skip that in such case
         def network_to_attributes(net)
           return if net.nil?
+
+          begin
+            bridge_name = net.bridge_name
+          rescue Libvirt::Error
+            bridge_name = ''
+          end
+
           {
             :uuid        => net.uuid,
             :name        => net.name,
-            :bridge_name => net.bridge_name
+            :bridge_name => bridge_name
           }
         end
       end


### PR DESCRIPTION
replacing https://github.com/fog/fog-libvirt/pull/78 seems github didn't reflect amended commit for some reason