### PR TITLE
Fix shell escape vulnerability

### DIFF
--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -347,6 +347,9 @@ module Fog
           ip_address.chomp
         end
 
+        # Locale-friendly removal of non-alpha nums
+        DOMAIN_CLEANUP_REGEXP = Regexp.compile('[\W_-]')
+
         # This retrieves the ip address of the mac address using ip_command
         # It returns an array of public and private ip addresses
         # Currently only one ip address is returned, but in the future this could be multiple
@@ -360,7 +363,7 @@ module Fog
           ip_command_global=service_arg.ip_command.nil? ? 'grep $mac /var/log/arpwatch.log|sed -e "s/new station//"|sed -e "s/changed ethernet address//g" |sed -e "s/reused old ethernet //" |tail -1 |cut -d ":" -f 4-| cut -d " " -f 3' : service_arg.ip_command
           ip_command_local=options[:ip_command].nil? ? ip_command_global : options[:ip_command]
 
-          ip_command="mac=#{mac}; server_name=#{name}; "+ip_command_local
+          ip_command="mac=#{mac}; server_name=#{name.gsub(DOMAIN_CLEANUP_REGEXP, '_')}; "+ip_command_local
 
           ip_address=nil
 


### PR DESCRIPTION
Older versions of libvirt (version 1002008 or order) or builds without dhcp leases feature compiled it are vulnerable to shell escape through for-libvirt. An attacker can execute arbitrary shell code either locally or remotely over ssh.

Luckily, most linux distributions these days have the dhcp leases feature compiled in and libvirt library in version that prevents from the affected code being executed.

This bug still deserves a fix if there's someone running an old hypervisor or calling those methods explicitly via send.

The following code prints "test" string into system log/journal by crafting a domain name to escape the shell:

```ruby
require "fog/libvirt"
compute = Fog::Compute.new(provider: :libvirt, libvirt_uri: "qemu:///system")
server = compute.servers.create(name: "test; logger test")
# Use this call to trigger the bug on systems with
# recent version of libvirt:
server.send(:addresses_ip_command)
```

The proposed fix is very simple so it could be backported if you choose to do so. I suggest to drop the code in question completely from the future versions of fog-libvirt.

Red Hat Security Response Team was made aware of this bug, no products are known to be affected, no CVE was filed.