### PR TITLE
Ruby 3.0.0 test suite fixes

### DIFF
--- a/tests/helper.rb
+++ b/tests/helper.rb
@@ -3,7 +3,7 @@ ENV['FOG_CREDENTIAL'] = ENV['FOG_CREDENTIAL'] || 'default'
 
 require 'fog/libvirt'
 
-Excon.defaults.merge!(:debug_request => true, :debug_response => true)
+Excon.defaults.merge!(debug_request: true, debug_response: true)
 
 require File.expand_path(File.join(File.dirname(__FILE__), 'helpers', 'mock_helper'))
 

--- a/tests/helpers/formats_helper.rb
+++ b/tests/helpers/formats_helper.rb
@@ -1,4 +1,6 @@
-require "fog/schema/data_validator"
+# frozen_string_literal: true
+
+require 'fog/schema/data_validator'
 
 # format related hackery
 # allows both true.is_a?(Fog::Boolean) and false.is_a?(Fog::Boolean)
@@ -15,62 +17,62 @@ module Fog
     module Array; end
   end
 end
-[FalseClass, TrueClass].each {|klass| klass.send(:include, Fog::Boolean)}
-[FalseClass, TrueClass, NilClass, Fog::Boolean].each {|klass| klass.send(:include, Fog::Nullable::Boolean)}
-[NilClass, String].each {|klass| klass.send(:include, Fog::Nullable::String)}
-[NilClass, Time].each {|klass| klass.send(:include, Fog::Nullable::Time)}
-[Integer, NilClass].each {|klass| klass.send(:include, Fog::Nullable::Integer)}
-[Float, NilClass].each {|klass| klass.send(:include, Fog::Nullable::Float)}
-[Hash, NilClass].each {|klass| klass.send(:include, Fog::Nullable::Hash)}
-[Array, NilClass].each {|klass| klass.send(:include, Fog::Nullable::Array)}
+[FalseClass, TrueClass].each { |klass| klass.send(:include, Fog::Boolean) }
+[FalseClass, TrueClass, NilClass, Fog::Boolean].each { |klass| klass.send(:include, Fog::Nullable::Boolean) }
+[NilClass, String].each { |klass| klass.send(:include, Fog::Nullable::String) }
+[NilClass, Time].each { |klass| klass.send(:include, Fog::Nullable::Time) }
+[Integer, NilClass].each { |klass| klass.send(:include, Fog::Nullable::Integer) }
+[Float, NilClass].each { |klass| klass.send(:include, Fog::Nullable::Float) }
+[Hash, NilClass].each { |klass| klass.send(:include, Fog::Nullable::Hash) }
+[Array, NilClass].each { |klass| klass.send(:include, Fog::Nullable::Array) }
 
 module Shindo
+  # Generates a Shindo test that compares a hash schema to the result
+  # of the passed in block returning true if they match.
+  #
+  # The schema that is passed in is a Hash or Array of hashes that
+  # have Classes in place of values. When checking the schema the
+  # value should match the Class.
+  #
+  # Strict mode will fail if the data has additional keys. Setting
+  # +strict+ to +false+ will allow additional keys to appear.
+  #
+  # @param [Hash] schema A Hash schema
+  # @param [Hash] options Options to change validation rules
+  # @option options [Boolean] :allow_extra_keys
+  #     If +true+ does not fail when keys are in the data that are
+  #     not specified in the schema. This allows new values to
+  #     appear in API output without breaking the check.
+  # @option options [Boolean] :allow_optional_rules
+  #     If +true+ does not fail if extra keys are in the schema
+  #     that do not match the data. Not recommended!
+  # @yield Data to check with schema
+  #
+  # @example Using in a test
+  #     Shindo.tests("comparing welcome data against schema") do
+  #       data = {:welcome => "Hello" }
+  #       data_matches_schema(:welcome => String) { data }
+  #     end
+  #
+  #     comparing welcome data against schema
+  #     + data matches schema
+  #
+  # @example Example schema
+  #     {
+  #       "id" => String,
+  #       "ram" => Integer,
+  #       "disks" => [
+  #         {
+  #           "size" => Float
+  #         }
+  #       ],
+  #       "dns_name" => Fog::Nullable::String,
+  #       "active" => Fog::Boolean,
+  #       "created" => DateTime
+  #     }
+  #
+  # @return [Boolean]
   class Tests
-    # Generates a Shindo test that compares a hash schema to the result
-    # of the passed in block returning true if they match.
-    #
-    # The schema that is passed in is a Hash or Array of hashes that
-    # have Classes in place of values. When checking the schema the
-    # value should match the Class.
-    #
-    # Strict mode will fail if the data has additional keys. Setting
-    # +strict+ to +false+ will allow additional keys to appear.
-    #
-    # @param [Hash] schema A Hash schema
-    # @param [Hash] options Options to change validation rules
-    # @option options [Boolean] :allow_extra_keys
-    #     If +true+ does not fail when keys are in the data that are
-    #     not specified in the schema. This allows new values to
-    #     appear in API output without breaking the check.
-    # @option options [Boolean] :allow_optional_rules
-    #     If +true+ does not fail if extra keys are in the schema
-    #     that do not match the data. Not recommended!
-    # @yield Data to check with schema
-    #
-    # @example Using in a test
-    #     Shindo.tests("comparing welcome data against schema") do
-    #       data = {:welcome => "Hello" }
-    #       data_matches_schema(:welcome => String) { data }
-    #     end
-    #
-    #     comparing welcome data against schema
-    #     + data matches schema
-    #
-    # @example Example schema
-    #     {
-    #       "id" => String,
-    #       "ram" => Integer,
-    #       "disks" => [
-    #         {
-    #           "size" => Float
-    #         }
-    #       ],
-    #       "dns_name" => Fog::Nullable::String,
-    #       "active" => Fog::Boolean,
-    #       "created" => DateTime
-    #     }
-    #
-    # @return [Boolean]
     def data_matches_schema(schema, options = {})
       test('data matches schema') do
         validator = Fog::Schema::DataValidator.new
@@ -84,9 +86,9 @@ module Shindo
     def formats(format, strict = true)
       test('has proper format') do
         if strict
-          options = {:allow_extra_keys => false, :allow_optional_rules => true}
+          options = { allow_extra_keys: false, allow_optional_rules: true }
         else
-          options = {:allow_extra_keys => true, :allow_optional_rules => true}
+          options = { allow_extra_keys: true, allow_optional_rules: true }
         end
         validator = Fog::Schema::DataValidator.new
         valid = validator.validate(yield, format, options)

--- a/tests/helpers/formats_helper_tests.rb
+++ b/tests/helpers/formats_helper_tests.rb
@@ -1,37 +1,37 @@
 Shindo.tests('test_helper', 'meta') do
 
   tests('comparing welcome data against schema') do
-    data = {:welcome => "Hello" }
-    data_matches_schema(:welcome => String) { data }
+    data = { welcome: 'Hello' }
+    data_matches_schema(welcome: String) { data }
   end
 
   tests('#data_matches_schema') do
     tests('when value matches schema expectation') do
-      data_matches_schema({"key" => String}) { {"key" => "Value"} }
+      data_matches_schema('key' => String) { { 'key' => 'Value' } }
     end
 
     tests('when values within an array all match schema expectation') do
-      data_matches_schema({"key" => [Integer]}) { {"key" => [1, 2]} }
+      data_matches_schema('key' => [Integer]) { { 'key' => [1, 2] } }
     end
 
     tests('when nested values match schema expectation') do
-      data_matches_schema({"key" => {:nested_key => String}}) { {"key" => {:nested_key => "Value"}} }
+      data_matches_schema('key' => { nested_key: String }) { { 'key' => { nested_key: 'Value' } } }
     end
 
     tests('when collection of values all match schema expectation') do
-      data_matches_schema([{"key" => String}]) { [{"key" => "Value"}, {"key" => "Value"}] }
+      data_matches_schema([{ 'key' => String }]) { [{ 'key' => 'Value' }, { 'key' => 'Value' }] }
     end
 
     tests('when collection is empty although schema covers optional members') do
-      data_matches_schema([{"key" => String}], {:allow_optional_rules => true}) { [] }
+      data_matches_schema([{ 'key' => String }], allow_optional_rules: true) { [] }
     end
 
     tests('when additional keys are passed and not strict') do
-      data_matches_schema({"key" => String}, {:allow_extra_keys => true}) { {"key" => "Value", :extra => "Bonus"} }
+      data_matches_schema({ 'key' => String }, allow_extra_keys: true) { { 'key' => 'Value', extra: 'Bonus' } }
     end
 
     tests('when value is nil and schema expects NilClass') do
-      data_matches_schema({"key" => NilClass}) { {"key" => nil} }
+      data_matches_schema('key' => NilClass) { { 'key' => nil } }
     end
 
     tests('when value and schema match as hashes') do
@@ -43,46 +43,45 @@ Shindo.tests('test_helper', 'meta') do
     end
 
     tests('when value is a Time') do
-      data_matches_schema({"time" => Time}) { {"time" => Time.now} }
+      data_matches_schema('time' => Time) { { 'time' => Time.now } }
     end
 
     tests('when key is missing but value should be NilClass (#1477)') do
-      data_matches_schema({"key" => NilClass}, {:allow_optional_rules => true}) { {} }
+      data_matches_schema({ 'key' => NilClass }, allow_optional_rules: true) { {} }
     end
 
     tests('when key is missing but value is nullable (#1477)') do
-      data_matches_schema({"key" => Fog::Nullable::String}, {:allow_optional_rules => true}) { {} }
+      data_matches_schema({ 'key' => Fog::Nullable::String }, allow_optional_rules: true) { {} }
     end
   end
 
   tests('#formats backwards compatible changes') do
-
     tests('when value matches schema expectation') do
-      formats({"key" => String}) { {"key" => "Value"} }
+      formats('key' => String) { { 'key' => 'Value' } }
     end
 
     tests('when values within an array all match schema expectation') do
-      formats({"key" => [Integer]}) { {"key" => [1, 2]} }
+      formats('key' => [Integer]) { { 'key' => [1, 2] } }
     end
 
     tests('when nested values match schema expectation') do
-      formats({"key" => {:nested_key => String}}) { {"key" => {:nested_key => "Value"}} }
+      formats('key' => { nested_key: String }) { { 'key' => { nested_key: 'Value' } } }
     end
 
     tests('when collection of values all match schema expectation') do
-      formats([{"key" => String}]) { [{"key" => "Value"}, {"key" => "Value"}] }
+      formats([{ 'key' => String }]) { [{ 'key' => 'Value' }, { 'key' => 'Value' }] }
     end
 
     tests('when collection is empty although schema covers optional members') do
-      formats([{"key" => String}]) { [] }
+      formats([{ 'key' => String }]) { [] }
     end
 
     tests('when additional keys are passed and not strict') do
-      formats({"key" => String}, false) { {"key" => "Value", :extra => "Bonus"} }
+      formats({ 'key' => String }, false) { { 'key' => 'Value', :extra => 'Bonus' } }
     end
 
     tests('when value is nil and schema expects NilClass') do
-      formats({"key" => NilClass}) { {"key" => nil} }
+      formats('key' => NilClass) { { 'key' => nil } }
     end
 
     tests('when value and schema match as hashes') do
@@ -94,17 +93,15 @@ Shindo.tests('test_helper', 'meta') do
     end
 
     tests('when value is a Time') do
-      formats({"time" => Time}) { {"time" => Time.now} }
+      formats('time' => Time) { { 'time' => Time.now } }
     end
 
     tests('when key is missing but value should be NilClass (#1477)') do
-      formats({"key" => NilClass}) { {} }
+      formats('key' => NilClass) { {} }
     end
 
     tests('when key is missing but value is nullable (#1477)') do
-      formats({"key" => Fog::Nullable::String}) { {} }
+      formats('key' => Fog::Nullable::String) { {} }
     end
-
   end
-
 end

--- a/tests/helpers/mock_helper.rb
+++ b/tests/helpers/mock_helper.rb
@@ -9,6 +9,6 @@ end
 # if in mocked mode, fill in some fake credentials for us
 if Fog.mock?
   Fog.credentials = {
-    :libvirt_uri                      => 'qemu://libvirt/system',
+    libvirt_uri:                       'qemu://libvirt/system',
   }.merge(Fog.credentials)
 end

--- a/tests/helpers/succeeds_helper.rb
+++ b/tests/helpers/succeeds_helper.rb
@@ -1,8 +1,8 @@
 module Shindo
   class Tests
-    def succeeds
+    def succeeds(&block)
       test('succeeds') do
-        !instance_eval(&Proc.new).nil?
+        !instance_eval(&Proc.new(&block)).nil?
       end
     end
   end

--- a/tests/helpers/succeeds_helper.rb
+++ b/tests/helpers/succeeds_helper.rb
@@ -2,7 +2,7 @@ module Shindo
   class Tests
     def succeeds
       test('succeeds') do
-        !!instance_eval(&Proc.new)
+        !instance_eval(&Proc.new).nil?
       end
     end
   end


### PR DESCRIPTION
This fixes test suite failure testing against Ruby 3.0. Similar fixes were already applied into fog-aws.

https://github.com/fog/fog-aws/commit/62256219f440253e9e9815b046f83143c0dd5a5b
https://github.com/fog/fog-aws/commit/359c8e0d58f4e6a193c9fd5b889bb1c59d11c4d4

The later patch would be actually enough to fix the Ruby 3.0.0 test issues, but it does not apply cleanly. Therefore I picked also the other changes.