### PR TITLE
Only set darwin socket path if it actually exists

### DIFF
--- a/lib/fog/libvirt/compute.rb
+++ b/lib/fog/libvirt/compute.rb
@@ -124,7 +124,7 @@ module Fog
           # if the socket exists
 
           socketpath="/var/run/libvirt/libvirt-sock"
-          if RUBY_PLATFORM =~ /darwin/ and File.exist?("socketpath")
+          if RUBY_PLATFORM =~ /darwin/ && File.exist?("socketpath")
             querystring=::URI.parse(uri).query
             if querystring.nil?
               append="?socket=#{socketpath}"

--- a/lib/fog/libvirt/compute.rb
+++ b/lib/fog/libvirt/compute.rb
@@ -120,15 +120,17 @@ module Fog
           # on macosx, chances are we are using libvirt through homebrew
           # the client will default to a socket location based on it's own location (/opt)
           # we conveniently point it to /var/run/libvirt/libvirt-sock
-          # if no socket option has been specified explicitly
+          # if no socket option has been specified explicitly and
+          # if the socket exists
 
-          if RUBY_PLATFORM =~ /darwin/
+          socketpath="/var/run/libvirt/libvirt-sock"
+          if RUBY_PLATFORM =~ /darwin/ and Pathname.new("socketpath").exist?
             querystring=::URI.parse(uri).query
             if querystring.nil?
-              append="?socket=/var/run/libvirt/libvirt-sock"
+              append="?socket=#{socketpath}"
             else
               if !::CGI.parse(querystring).key?("socket")
-                append="&socket=/var/run/libvirt/libvirt-sock"
+                append="&socket=#{socketpath}"
               end
             end
           end

--- a/lib/fog/libvirt/compute.rb
+++ b/lib/fog/libvirt/compute.rb
@@ -124,7 +124,7 @@ module Fog
           # if the socket exists
 
           socketpath="/var/run/libvirt/libvirt-sock"
-          if RUBY_PLATFORM =~ /darwin/ && File.exist?("socketpath")
+          if RUBY_PLATFORM =~ /darwin/ && File.exist?(socketpath)
             querystring=::URI.parse(uri).query
             if querystring.nil?
               append="?socket=#{socketpath}"

--- a/lib/fog/libvirt/compute.rb
+++ b/lib/fog/libvirt/compute.rb
@@ -124,7 +124,7 @@ module Fog
           # if the socket exists
 
           socketpath="/var/run/libvirt/libvirt-sock"
-          if RUBY_PLATFORM =~ /darwin/ and Pathname.new("socketpath").exist?
+          if RUBY_PLATFORM =~ /darwin/ and File.exist?("socketpath")
             querystring=::URI.parse(uri).query
             if querystring.nil?
               append="?socket=#{socketpath}"

--- a/lib/fog/libvirt/compute.rb
+++ b/lib/fog/libvirt/compute.rb
@@ -128,10 +128,8 @@ module Fog
             querystring=::URI.parse(uri).query
             if querystring.nil?
               append="?socket=#{socketpath}"
-            else
-              if !::CGI.parse(querystring).key?("socket")
-                append="&socket=#{socketpath}"
-              end
+            elsif !::CGI.parse(querystring).key?("socket")
+              append="&socket=#{socketpath}"
             end
           end
           uri+append


### PR DESCRIPTION
I couldn't find more context behind this built-in logic that modifies the URI beyond what's written in the comment. It seems that it was introduced with the initial commit.

Despite what the comment suggests, from my own experience this logic in fact seems to make it _less_ convenient to use the library on darwin, because of the assumptions made about how libvirt runs and where does it place the socket.

At the time of writing the default Homebrew formula for libvirt by default runs in the session mode (without elevated privileges), which ends up placing the socket(s) under `~/.cache/libvirt/` directory. Alternatively the service may be launched as root, in which case the sockets end up in `/usr/local/var/run/libvirt/`. Neither of these paths seem to match the one in source code.

Either way even without any configuration and service file, libvirt is capable of starting the daemon automatically upon connection to just `qemu:///session` (without explicit socket argument) and consumers of fog-libvirt cannot take advantage of this autostart feature.

This is also mentioned here: https://blog.wikichoon.com/2016/01/qemusystem-vs-qemusession.html

I would be open to removing that logic entirely but I thought this patch strikes a balance wrt backwards compatibility.

Let me know what you think!