### PR TITLE
Make volume owner and group optional

### DIFF
--- a/lib/fog/libvirt/models/compute/templates/volume.xml.erb
+++ b/lib/fog/libvirt/models/compute/templates/volume.xml.erb
@@ -5,8 +5,12 @@
         <target>
           <format type="<%= format_type %>"/>
           <permissions>
+            <% if owner -%>
             <owner><%= owner %></owner>
+            <% end -%>
+            <% if group -%>
             <group><%= group %></group>
+            <% end -%>
             <mode>0744</mode>
             <label>virt_image_t</label>
           </permissions>

--- a/lib/fog/libvirt/models/compute/volume.rb
+++ b/lib/fog/libvirt/models/compute/volume.rb
@@ -108,8 +108,8 @@ module Fog
             :name        => randomized_name,
             :capacity    => "10G",
             :allocation  => "1G",
-            :owner       => "0",
-            :group       => "0",
+            :owner       => nil,
+            :group       => nil,
           }
         end
 


### PR DESCRIPTION
Always passing this makes it required. This breaks using libvirt via qemu:///session. By not passing it at all, it leaves it up to libvirt to deal with.