### PR TITLE
Exception namespace fixed for list networks

### DIFF
--- a/lib/fog/libvirt/requests/compute/list_networks.rb
+++ b/lib/fog/libvirt/requests/compute/list_networks.rb
@@ -31,7 +31,7 @@ module Fog
 
           begin
             bridge_name = net.bridge_name
-          rescue Libvirt::Error
+          rescue ::Libvirt::Error
             bridge_name = ''
           end
 


### PR DESCRIPTION
The problem:

```
2021-05-19T12:03:28 [I|app|60036495]   Rendered compute_resources_vms/import.html.erb within layouts/application (Duration: 228.1ms | Allocations: 54224)
2021-05-19T12:03:28 [W|app|60036495] uninitialized constant Fog::Libvirt::Error
 60036495 | Did you mean?  Fog::Errors
 60036495 |                IOError
 60036495 |                Errno
2021-05-19T12:03:28 [I|app|60036495] Backtrace for 'uninitialized constant Fog::Libvirt::Error
 60036495 | Did you mean?  Fog::Errors
 60036495 |                IOError
 60036495 |                Errno' error (ActionView::Template::Error): uninitialized constant Fog::Libvirt::Error
 60036495 | Did you mean?  Fog::Errors
 60036495 |                IOError
 60036495 |                Errno
 60036495 | /opt/theforeman/tfm/root/usr/share/gems/gems/fog-libvirt-0.8.0/lib/fog/libvirt/requests/compute/list_networks.rb:34:in `rescue in network_to_attributes'
 60036495 | /opt/theforeman/tfm/root/usr/share/gems/gems/fog-libvirt-0.8.0/lib/fog/libvirt/requests/compute/list_networks.rb:32:in `network_to_attributes'
 60036495 | /opt/theforeman/tfm/root/usr/share/gems/gems/fog-libvirt-0.8.0/lib/fog/libvirt/requests/compute/list_networks.rb:9:in `block in list_networks'
 60036495 | /opt/theforeman/tfm/root/usr/share/gems/gems/fog-libvirt-0.8.0/lib/fog/libvirt/requests/compute/list_networks.rb:8:in `each'
 60036495 | /opt/theforeman/tfm/root/usr/share/gems/gems/fog-libvirt-0.8.0/lib/fog/libvirt/requests/compute/list_networks.rb:8:in `list_networks'
 60036495 | /opt/theforeman/tfm/root/usr/share/gems/gems/fog-libvirt-0.8.0/lib/fog/libvirt/models/compute/networks.rb:11:in `all'
```