### PR TITLE
Use a filter to allow listing of inactive pools

### DIFF
--- a/lib/fog/libvirt/requests/compute/list_pools.rb
+++ b/lib/fog/libvirt/requests/compute/list_pools.rb
@@ -50,16 +50,9 @@ module Fog
 
       class Mock
         def list_pools(filter = { })
-          @pool_data.map do |pool|
-            Compute::Real.send(:pool_to_attributes, pool, filter[:include_inactive])
-          end.compact
-        end
-
-        def initialize(options = { })
-          @pool_data = [
-            FakePool.new(mock_pool('pool1')),
-            FakePool.new(mock_pool('pool1'))
-          ]
+          pool1 = mock_pool 'pool1'
+          pool2 = mock_pool 'pool1'
+          [pool1, pool2]
         end
 
         def mock_pool name
@@ -69,53 +62,11 @@ module Fog
               :autostart      => true,
               :active         => true,
               :name           => name,
-              :info           => {
-                :allocation     => 123456789,
-                :capacity       => 123456789,
-                :state          => 2 # running
-              },
-              :num_of_volumes => 3
+              :allocation     => 123456789,
+              :capacity       => 123456789,
+              :num_of_volumes => 3,
+              :state          => 2 # running
           }
-        end
-
-        def add_pool(pool_attributes)
-          @pool_data.append(FakePool.new(pool_attributes))
-        end
-
-        class FakePool < Fog::Model
-          # Fake pool object to allow exercising the internal parsing of pools
-          # returned by the client queries
-          identity :uuid
-
-          attribute :persistent
-          attribute :autostart
-          attribute :active
-          attribute :name
-          attribute :num_of_volumes
-          attr_reader :info
-
-          class FakeInfo < Fog::Model
-            attribute :allocation
-            attribute :capacity
-            attribute :state
-          end
-
-          def initialize(attributes = { })
-            @info = FakeInfo.new(attributes.delete(:info))
-            super(attributes)
-          end
-
-          def active?
-            active
-          end
-
-          def autostart?
-            autostart
-          end
-
-          def persistent?
-            persistent
-          end
         end
       end
     end

--- a/lib/fog/libvirt/requests/compute/list_pools.rb
+++ b/lib/fog/libvirt/requests/compute/list_pools.rb
@@ -5,19 +5,22 @@ module Fog
         def list_pools(filter = { })
           data=[]
           if filter.key?(:name)
-            data << find_pool_by_name(filter[:name])
+            data << find_pool_by_name(filter[:name], filter[:include_inactive])
           elsif filter.key?(:uuid)
-            data << find_pool_by_uuid(filter[:uuid])
+            data << find_pool_by_uuid(filter[:uuid], filter[:include_inactive])
           else
             (client.list_storage_pools + client.list_defined_storage_pools).each do |name|
-              data << find_pool_by_name(name)
+              data << find_pool_by_name(name, filter[:include_inactive])
             end
           end
           data.compact
         end
 
         private
-        def pool_to_attributes(pool)
+
+        private_class_method def self.pool_to_attributes(pool, include_inactive = nil)
+          return nil unless pool.active? || include_inactive
+
           states=[:inactive, :building, :running, :degrated, :inaccessible]
           {
             :uuid           => pool.uuid,
@@ -27,19 +30,19 @@ module Fog
             :name           => pool.name,
             :allocation     => pool.info.allocation,
             :capacity       => pool.info.capacity,
-            :num_of_volumes => pool.num_of_volumes,
+            :num_of_volumes => pool.active? ? pool.num_of_volumes : nil,
             :state          => states[pool.info.state]
           }
         end
 
-        def find_pool_by_name name
-          pool_to_attributes(client.lookup_storage_pool_by_name(name))
+        def find_pool_by_name name, include_inactive
+          pool_to_attributes(client.lookup_storage_pool_by_name(name), include_inactive)
         rescue ::Libvirt::RetrieveError
           nil
         end
 
-        def find_pool_by_uuid uuid
-          pool_to_attributes(client.lookup_storage_pool_by_uuid(uuid))
+        def find_pool_by_uuid uuid, include_inactive
+          pool_to_attributes(client.lookup_storage_pool_by_uuid(uuid), include_inactive)
         rescue ::Libvirt::RetrieveError
           nil
         end
@@ -47,9 +50,16 @@ module Fog
 
       class Mock
         def list_pools(filter = { })
-          pool1 = mock_pool 'pool1'
-          pool2 = mock_pool 'pool1'
-          [pool1, pool2]
+          @pool_data.map do |pool|
+            Compute::Real.send(:pool_to_attributes, pool, filter[:include_inactive])
+          end.compact
+        end
+
+        def initialize(options = { })
+          @pool_data = [
+            FakePool.new(mock_pool('pool1')),
+            FakePool.new(mock_pool('pool1'))
+          ]
         end
 
         def mock_pool name
@@ -59,11 +69,53 @@ module Fog
               :autostart      => true,
               :active         => true,
               :name           => name,
-              :allocation     => 123456789,
-              :capacity       => 123456789,
-              :num_of_volumes => 3,
-              :state          => :running
+              :info           => {
+                :allocation     => 123456789,
+                :capacity       => 123456789,
+                :state          => 2 # running
+              },
+              :num_of_volumes => 3
           }
+        end
+
+        def add_pool(pool_attributes)
+          @pool_data.append(FakePool.new(pool_attributes))
+        end
+
+        class FakePool < Fog::Model
+          # Fake pool object to allow exercising the internal parsing of pools
+          # returned by the client queries
+          identity :uuid
+
+          attribute :persistent
+          attribute :autostart
+          attribute :active
+          attribute :name
+          attribute :num_of_volumes
+          attr_reader :info
+
+          class FakeInfo < Fog::Model
+            attribute :allocation
+            attribute :capacity
+            attribute :state
+          end
+
+          def initialize(attributes = { })
+            @info = FakeInfo.new(attributes.delete(:info))
+            super(attributes)
+          end
+
+          def active?
+            active
+          end
+
+          def autostart?
+            autostart
+          end
+
+          def persistent?
+            persistent
+          end
         end
       end
     end

--- a/lib/fog/libvirt/requests/compute/list_pools.rb
+++ b/lib/fog/libvirt/requests/compute/list_pools.rb
@@ -65,7 +65,7 @@ module Fog
               :allocation     => 123456789,
               :capacity       => 123456789,
               :num_of_volumes => 3,
-              :state          => 2 # running
+              :state          => :running
           }
         end
       end

--- a/tests/libvirt/requests/compute/list_pools_tests.rb
+++ b/tests/libvirt/requests/compute/list_pools_tests.rb
@@ -1,3 +1,39 @@
+class FakePool < Fog::Model
+  # Fake pool object to allow exercising the internal parsing of pools
+  # returned by the client queries
+  identity :uuid
+
+  attribute :persistent
+  attribute :autostart
+  attribute :active
+  attribute :name
+  attribute :num_of_volumes
+  attr_reader :info
+
+  class FakeInfo < Fog::Model
+    attribute :allocation
+    attribute :capacity
+    attribute :state
+  end
+
+  def initialize(attributes = {})
+    @info = FakeInfo.new(attributes.dup.delete(:info))
+    super(attributes)
+  end
+
+  def active?
+    active
+  end
+
+  def autostart?
+    autostart
+  end
+
+  def persistent?
+    persistent
+  end
+end
+
 Shindo.tests("Fog::Compute[:libvirt] | list_pools request", 'libvirt') do
 
   compute = Fog::Compute[:libvirt]
@@ -8,14 +44,28 @@ Shindo.tests("Fog::Compute[:libvirt] | list_pools request", 'libvirt') do
     test("should have two pools") { response.length == 2 }
   end
 
-  tests("Lists Inactive Pools") do
-    inactive_pool = compute.mock_pool('inactive_pool1')
-    inactive_pool[:active] = false
-    compute.add_pool(inactive_pool)
+  tests("Handle Inactive Pools") do
+    inactive_pool = {
+      :uuid => 'pool.uuid',
+      :persistent => true,
+      :autostart => true,
+      :active => false,
+      :name => 'inactive_pool1',
+      :info => {
+        :allocation => 123456789,
+        :capacity => 123456789,
+        :state => 2 # running
+      },
+      :num_of_volumes => 3
+    }
 
-    response = compute.list_pools({ :include_inactive => true })
+    response = ::Fog::Libvirt::Compute::Real.send(:pool_to_attributes, FakePool.new(inactive_pool), true)
 
-    test("should be an array") { response.kind_of? Array }
-    test("should have three pools") { response.length == 3 }
+    test("should be hash of attributes") { response.kind_of? Hash }
+
+    response = ::Fog::Libvirt::Compute::Real.send(:pool_to_attributes, FakePool.new(inactive_pool))
+
+    test("should be nil") { response.nil? }
+
   end
 end

--- a/tests/libvirt/requests/compute/list_pools_tests.rb
+++ b/tests/libvirt/requests/compute/list_pools_tests.rb
@@ -1,0 +1,21 @@
+Shindo.tests("Fog::Compute[:libvirt] | list_pools request", 'libvirt') do
+
+  compute = Fog::Compute[:libvirt]
+
+  tests("Lists Pools") do
+    response = compute.list_pools
+    test("should be an array") { response.kind_of? Array }
+    test("should have two pools") { response.length == 2 }
+  end
+
+  tests("Lists Inactive Pools") do
+    inactive_pool = compute.mock_pool('inactive_pool1')
+    inactive_pool[:active] = false
+    compute.add_pool(inactive_pool)
+
+    response = compute.list_pools({ :include_inactive => true })
+
+    test("should be an array") { response.kind_of? Array }
+    test("should have three pools") { response.length == 3 }
+  end
+end


### PR DESCRIPTION
Allow for an `:include_inactive` filter attribute to determine whether
to include or exclude inactive pools and handle correctly setting the
number of volumes in the case it is inactive.

Current testing approach requires modifying the internal function in
order to allow the Mock to call it to ensure it is exercised correctly.

Fixes: #12
