### PR TITLE
Version 0.9.0

### DIFF
--- a/lib/fog/libvirt/version.rb
+++ b/lib/fog/libvirt/version.rb
@@ -1,5 +1,5 @@
 module Fog
   module Libvirt
-    VERSION = '0.8.0'
+    VERSION = '0.9.0'
   end
 end


### PR DESCRIPTION
Any objections to cutting a new release? Here is what is new:

* Shell escape vulnerability
* Support for S390x
* Modernized Ruby 2.X syntax
* Updated compatibility with Ruby 3.X
* Changes in the CI infrastructure (Github Actions)
* Fix for MacOS (Darwin) UNIX socket path
* Fix for rescue in listing network

Would you mind creating a git tag and building and pushing the gem, @geemus, if there are no objections? Thank you!