### PR TITLE
Add flags option to server.destroy

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,3 +18,6 @@ SignalException:
   Description: 'Do not enforce use of fail when raising exceptions.'
   # Valid values are: semantic, only_raise and only_fail
   EnforcedStyle: only_raise
+
+Metrics/ClassLength:
+  Enabled: false

--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -90,9 +90,13 @@ module Fog
           volumes.first.path if volumes and volumes.first
         end
 
-        def destroy(options={ :destroy_volumes => false})
+        def destroy(options={ :destroy_volumes => false, :flags => 0 })
           poweroff unless stopped?
-          service.vm_action(uuid, :undefine)
+          if options[:flags].zero?
+            service.vm_action(uuid, :undefine)
+          else
+            service.vm_action(uuid, :undefine, options[:flags])
+          end
           volumes.each { |vol| vol.destroy } if options[:destroy_volumes]
           true
         end

--- a/lib/fog/libvirt/requests/compute/vm_action.rb
+++ b/lib/fog/libvirt/requests/compute/vm_action.rb
@@ -2,15 +2,15 @@ module Fog
   module Libvirt
     class Compute
       class Real
-        def vm_action(uuid, action)
+        def vm_action(uuid, action, *params)
           domain = client.lookup_domain_by_uuid(uuid)
-          domain.send(action)
+          domain.send(action, *params)
           true
         end
       end
 
       class Mock
-        def vm_action(uuid, action)
+        def vm_action(uuid, action, *params)
           true
         end
       end


### PR DESCRIPTION
A call to `server.destroy` ultimately ends in a call to `virDomainUndefineFlags`. Right now there is no way to set the flags argument with which `virDomainUndefineFlags` gets called. This patch provides such an option to the caller.

This is needed to address [vagrant-libvirt#1027](https://github.com/vagrant-libvirt/vagrant-libvirt/issues/1027). Specifically, vagrant-libvirt needs to be able to set the `VIR_DOMAIN_UNDEFINE_NVRAM` flag when calling `destroy` on a domain configured with NVRAM.

There is one gotcha to this. If libvirt-ruby is built without `HAVE_VIRDOMAINUNDEFINEFLAGS` the call does not end in `virDomainUndefineFlags` but in `virDomainUndefine`. In that case a non-zero flags argument will result in an error. I have found no documentation or reference to that build flag. All I know for sure is that the package in the Fedora 34 repo is built with it enabled, and the user who created aformentioned issue in vagrant-libvirt also has such a build. But given that `virDomainUndefineFlags` was implemented [seven years ago](https://gitlab.com/libvirt/libvirt-ruby/-/commit/59e749fca594fdaa29bd4b3d34dfac00308286f9), it is probably ok?

Beware, this is my first contact with ruby. I hope I didn't do anything completely stupid...