### PR TITLE
Add 'pmsuspended' to possible virtual machine states.

### DIFF
--- a/lib/fog/libvirt/requests/compute/list_domains.rb
+++ b/lib/fog/libvirt/requests/compute/list_domains.rb
@@ -66,7 +66,7 @@ module Fog
         end
 
         def domain_to_attributes(dom)
-          states= %w(nostate running blocked paused shutting-down shutoff crashed)
+          states= %w(nostate running blocked paused shutting-down shutoff crashed pmsuspended)
 
           begin
             {


### PR DESCRIPTION
In case a virtual machine goes in to libvirt mode `pmsuspended`,
situation is not handled by fog-libvirt currently. This leads to issues
in other projects like vagrant-libvirt. Suspend mode can be either the
case if domain is set into suspend (by for example systemctl suspend) or
hypervisor sets VM into suspended mode due to lack of resources.

Full discussion:

 vagrant-libvirt/vagrant-libvirt#1200

Patch adds the state to possible virtual machine states.