### PR TITLE
Remove NVRAM in undefine call

### DIFF
--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -92,7 +92,7 @@ module Fog
 
         def destroy(options={ :destroy_volumes => false})
           poweroff unless stopped?
-          service.vm_action(uuid, :undefine)
+          service.vm_action(uuid, :undefine, 4) # Remove NVRAM if exists
           volumes.each { |vol| vol.destroy } if options[:destroy_volumes]
           true
         end

--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -92,7 +92,7 @@ module Fog
 
         def destroy(options={ :destroy_volumes => false})
           poweroff unless stopped?
-          service.vm_action(uuid, :undefine, 4) # Remove NVRAM if exists
+          service.vm_action(uuid, :undefine, Libvirt::Domain::UNDEFINE_NVRAM) # Remove NVRAM if exists
           volumes.each { |vol| vol.destroy } if options[:destroy_volumes]
           true
         end

--- a/lib/fog/libvirt/requests/compute/vm_action.rb
+++ b/lib/fog/libvirt/requests/compute/vm_action.rb
@@ -2,9 +2,9 @@ module Fog
   module Libvirt
     class Compute
       class Real
-        def vm_action(uuid, action)
+        def vm_action(uuid, action, *args)
           domain = client.lookup_domain_by_uuid(uuid)
-          domain.send(action)
+          domain.send(action, *args)
           true
         end
       end


### PR DESCRIPTION
1. Use splat to pass any argument to the function call
2. In ```undefine```, pass the argument to remove the NVRAM

Arguably, the flag could come from the caller, and not from fog-libvirt itself. What do you think ?

PR related to https://github.com/vagrant-libvirt/vagrant-libvirt/pull/1372