### PR TITLE
Avoid querying for all networks by default

### DIFF
--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -411,13 +411,11 @@ module Fog
           ip_address = nil
           nic = self.nics.find {|nic| nic.mac==mac}
           if !nic.nil?
-            service.networks.all.each do |net|
-              if net.name == nic.network
-                leases = net.dhcp_leases(mac, 0)
-                # Assume the lease expiring last is the current IP address
-                ip_address = leases.sort_by { |lse| lse["expirytime"] }.last["ipaddr"] if !leases.empty?
-                break
-              end
+            net = service.networks.all(:name => nic.network).first
+            if !net.nil?
+              leases = net.dhcp_leases(mac, 0)
+              # Assume the lease expiring last is the current IP address
+              ip_address = leases.sort_by { |lse| lse["expirytime"] }.last["ipaddr"] if !leases.empty?
             end
           end
 

--- a/lib/fog/libvirt/requests/compute/list_networks.rb
+++ b/lib/fog/libvirt/requests/compute/list_networks.rb
@@ -44,8 +44,8 @@ module Fog
       end
 
       class Mock
-        def list_networks(filters={ })
-          [ {
+        def list_networks(filter={ })
+          networks = [ {
               :uuid        => 'a29146ea-39b2-412d-8f53-239eef117a32',
               :name        => 'net1',
               :bridge_name => 'virbr0'
@@ -56,6 +56,16 @@ module Fog
               :bridge_name => 'virbr1'
             }
           ]
+          return networks if filter.empty?
+
+          case filter.keys.first
+            when :uuid
+              [networks.find(:uuid => filter[:uuid]).first]
+            when :name
+              [networks.find(:name => filter[:name]).first]
+            else
+              networks
+          end
         end
       end
     end


### PR DESCRIPTION
Given the network attribute of the nic is assumed to exist, provide this
as a filter attribute to skip querying libvirt for all networks and
instead request only the one relevant.

This can help avoid a race condition where multiple sets of vagrant
machines are being run on the same host using different networks where
during delete/destroy the networks of one are removed and yet at the
same time the other environment may attempt to access the attributes.

Relates-to: vagrant-libvirt/vagrant-libvirt#1438
