### PR TITLE
fix disk type for block devices on QEMU >= 6.0

### DIFF
--- a/lib/fog/libvirt/models/compute/templates/server.xml.erb
+++ b/lib/fog/libvirt/models/compute/templates/server.xml.erb
@@ -72,9 +72,9 @@
       <% end %>
     </disk>
   <% else %>
-    <disk type='file' device='disk'>
+    <disk type='block' device='disk'>
       <driver name='qemu' type='<%= vol.format_type %>'/>
-      <source file='<%= vol.path %>'/>
+      <source dev='<%= vol.path %>'/>
       <%# we need to ensure a unique target dev -%>
       <target dev='vd<%= ('a'..'z').to_a[volumes.index(vol)] %>' bus='virtio'/>
     </disk>


### PR DESCRIPTION
since QEMU version 6.0 [1], you can't use the file block driver with block devices.

[1] https://wiki.qemu.org/ChangeLog/6.0#Incompatible_changes