### PR TITLE
Ensure pool_to_attributes method can be called

### DIFF
--- a/lib/fog/libvirt/requests/compute/list_pools.rb
+++ b/lib/fog/libvirt/requests/compute/list_pools.rb
@@ -1,7 +1,30 @@
 module Fog
   module Libvirt
     class Compute
+      module Shared
+        private
+
+        def pool_to_attributes(pool, include_inactive = nil)
+          return nil unless pool.active? || include_inactive
+
+          states=[:inactive, :building, :running, :degrated, :inaccessible]
+          {
+            :uuid           => pool.uuid,
+            :persistent     => pool.persistent?,
+            :autostart      => pool.autostart?,
+            :active         => pool.active?,
+            :name           => pool.name,
+            :allocation     => pool.info.allocation,
+            :capacity       => pool.info.capacity,
+            :num_of_volumes => pool.active? ? pool.num_of_volumes : nil,
+            :state          => states[pool.info.state]
+          }
+        end
+      end
+
       class Real
+        include Shared
+
         def list_pools(filter = { })
           data=[]
           if filter.key?(:name)
@@ -18,23 +41,6 @@ module Fog
 
         private
 
-        private_class_method def self.pool_to_attributes(pool, include_inactive = nil)
-          return nil unless pool.active? || include_inactive
-
-          states=[:inactive, :building, :running, :degrated, :inaccessible]
-          {
-            :uuid           => pool.uuid,
-            :persistent     => pool.persistent?,
-            :autostart      => pool.autostart?,
-            :active         => pool.active?,
-            :name           => pool.name,
-            :allocation     => pool.info.allocation,
-            :capacity       => pool.info.capacity,
-            :num_of_volumes => pool.active? ? pool.num_of_volumes : nil,
-            :state          => states[pool.info.state]
-          }
-        end
-
         def find_pool_by_name name, include_inactive
           pool_to_attributes(client.lookup_storage_pool_by_name(name), include_inactive)
         rescue ::Libvirt::RetrieveError
@@ -49,6 +55,8 @@ module Fog
       end
 
       class Mock
+        include Shared
+
         def list_pools(filter = { })
           pool1 = mock_pool 'pool1'
           pool2 = mock_pool 'pool1'

--- a/tests/libvirt/requests/compute/list_pools_tests.rb
+++ b/tests/libvirt/requests/compute/list_pools_tests.rb
@@ -59,11 +59,11 @@ Shindo.tests("Fog::Compute[:libvirt] | list_pools request", 'libvirt') do
       :num_of_volumes => 3
     }
 
-    response = ::Fog::Libvirt::Compute::Real.send(:pool_to_attributes, FakePool.new(inactive_pool), true)
+    response = compute.send(:pool_to_attributes, FakePool.new(inactive_pool), true)
 
     test("should be hash of attributes") { response.kind_of? Hash }
 
-    response = ::Fog::Libvirt::Compute::Real.send(:pool_to_attributes, FakePool.new(inactive_pool))
+    response = compute.send(:pool_to_attributes, FakePool.new(inactive_pool))
 
     test("should be nil") { response.nil? }
 


### PR DESCRIPTION
Cannot call a private class method easily from an instance, therefore
revert back to using a standard private method, but move it into the
Shared module and include in both mock and real to allow tests to
exercise handling of inactive pools
