### PR TITLE
Update development dependency versions

### DIFF
--- a/fog-libvirt.gemspec
+++ b/fog-libvirt.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("shindo", "~> 0.3.4")
   s.add_development_dependency("simplecov")
   s.add_development_dependency("yard")
-  s.add_development_dependency("mocha", "~> 1.15.0")
+  s.add_development_dependency("mocha", ">= 1.15", "< 3")
 
   # Let's not ship dot files and gemfiles
   git_files = `git ls-files`.split("\n")

--- a/fog-libvirt.gemspec
+++ b/fog-libvirt.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("minitest-stub-const")
   s.add_development_dependency("pry")
   s.add_development_dependency("rake")
-  s.add_development_dependency("rubocop") if RUBY_VERSION > "2.0"
+  s.add_development_dependency("rubocop")
   s.add_development_dependency("shindo", "~> 0.3.4")
   s.add_development_dependency("simplecov")
   s.add_development_dependency("yard")


### PR DESCRIPTION
Replaces https://github.com/fog/fog-libvirt/pull/122. By pinning to the minor version instead of the patch version we shouldn't have to bump the dependency so often.