### PR TITLE
Deal with no flags passed to Server#destroy

### DIFF
--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -92,7 +92,7 @@ module Fog
 
         def destroy(options={ :destroy_volumes => false, :flags => 0 })
           poweroff unless stopped?
-          if options[:flags].zero?
+          if options.fetch(:flags, 0).zero?
             service.vm_action(uuid, :undefine)
           else
             service.vm_action(uuid, :undefine, options[:flags])


### PR DESCRIPTION
In 085a7c89596e989921dccd33dd954afbb37df27a it became possible to pass flags to Server#destroy but if the caller didn't pass flags in opts it failed because it was essentially nil.zero? which isn't defined.

I wasn't sure if I should drop the defaults for flags in options, but decided to keep it in to "document" the API.