### PR TITLE
Set the default machine type to q35 on i686 and x86_64

### DIFF
--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -295,12 +295,16 @@ module Fog
               end
 
               unless cpu.empty?
-                if cpu[:mode]
-                  xml.cpu(:mode => cpu[:mode])
-                else
+                if cpu.dig(:model, :name)
                   xml.cpu do
                     xml.model(cpu.dig(:model, :name), :fallback => cpu.dig(:model, :fallback) || "allow")
                   end
+                else
+                  xml.cpu(
+                    :mode => cpu.dig(:model, :name) || "host-passthrough",
+                    :check => cpu.fetch(:check, "none"),
+                    :migratable => cpu.fetch(:migratable, "on")
+                  )
                 end
               end
 

--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -282,7 +282,8 @@ module Fog
 
               xml.vcpu(cpus)
               xml.os do
-                xml.type(os_type, :arch => arch)
+                type = xml.type(os_type, :arch => arch)
+                type[:machine] = "q35" if ["i686", "x86_64"].include?(arch)
 
                 boot_order.each do |dev|
                   xml.boot(:dev => dev)
@@ -291,7 +292,6 @@ module Fog
               xml.features do
                 xml.acpi
                 xml.apic
-                xml.pae
               end
 
               unless cpu.empty?
@@ -308,7 +308,11 @@ module Fog
                 end
               end
 
-              xml.clock(:offset => "utc")
+              xml.clock(:offset => "utc") do
+                xml.timer(:name => "rtc", :tickpolicy => "catchup")
+                xml.timer(:name => "pit", :tickpolicy => "delay")
+                xml.timer(:name => "hpet", :present => "no")
+              end
 
               xml.devices do
                 ceph_args = read_ceph_args

--- a/lib/fog/libvirt/requests/compute/list_domains.rb
+++ b/lib/fog/libvirt/requests/compute/list_domains.rb
@@ -109,7 +109,7 @@ module Fog
               :memory_size     => 6,
               :cpus            => 5,
               :autostart       => false,
-              :os_type         => "RHEL6",
+              :os_type         => "hvm",
               :active          => false,
               :vnc_port        => 5910,
               :boot_order      => boot_order(xml),

--- a/tests/libvirt/models/compute/server_tests.rb
+++ b/tests/libvirt/models/compute/server_tests.rb
@@ -77,6 +77,7 @@ Shindo.tests('Fog::Compute[:libvirt] | server model', ['libvirt']) do
         xml = server.to_xml
         xml.match?(/<disk type="block" device="disk">/) && xml.match?(%r{<source dev="/dev/sda"/>})
       end
+      test("with q35 machine type on x86_64") { server.to_xml.match?(%r{<type arch="x86_64" machine="q35">hvm</type>}) }
     end
   end
 end


### PR DESCRIPTION
The pc type has been deprecated and on EL9 it's even unsupported. The type on aarch64 is virt, so there we continue to rely on the default.

This PR includes https://github.com/fog/fog-libvirt/pull/94 because it's easier to build on than the current template.

Right now it's untested whether this XML actually works.