### PR TITLE
Fix disk type for block devices on QEMU >= 6.0

### DIFF
--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -331,9 +331,14 @@ module Fog
                       xml.target(:dev => target_device, :bus => args["bus_type"] == "virtio" ? "virtio" : "scsi")
                     end
                   else
-                    xml.disk(:type => "file", :device => "disk") do
+                    is_block = volume.path.start_with?("/dev/")
+                    xml.disk(:type => is_block ? "block" : "file", :device => "disk") do
                       xml.driver(:name => "qemu", :type => volume.format_type)
-                      xml.source(:file => volume.path)
+                      if is_block
+                        xml.source(:dev => volume.path)
+                      else
+                        xml.source(:file => volume.path)
+                      end
                       xml.target(:dev => target_device, :bus => "virtio")
                     end
                   end

--- a/tests/libvirt/models/compute/server_tests.rb
+++ b/tests/libvirt/models/compute/server_tests.rb
@@ -61,6 +61,22 @@ Shindo.tests('Fog::Compute[:libvirt] | server model', ['libvirt']) do
     test('be a kind of Fog::Libvirt::Compute::Server') { server.kind_of? Fog::Libvirt::Compute::Server }
     tests("serializes to xml") do
       test("with memory") { server.to_xml.match?(%r{<memory>\d+</memory>}) }
+      test("with disk of type file") do
+        xml = server.to_xml
+        xml.match?(/<disk type="file" device="disk">/) && xml.match?(%r{<source file="path/to/disk"/>})
+      end
+      test("with disk of type block") do
+        server = Fog::Libvirt::Compute::Server.new(
+          {
+            :nics => [],
+            :volumes => [
+              Fog::Libvirt::Compute::Volume.new({ :path => "/dev/sda", :pool_name => "dummy" })
+            ]
+          }
+        )
+        xml = server.to_xml
+        xml.match?(/<disk type="block" device="disk">/) && xml.match?(%r{<source dev="/dev/sda"/>})
+      end
     end
   end
 end


### PR DESCRIPTION
Since [QEMU version 6.0](https://wiki.qemu.org/ChangeLog/6.0#Incompatible_changes), you can't use the file block driver with block devices. It tries to detect block devices by looking at the file path.

This builds on https://github.com/fog/fog-libvirt/pull/116, but I don't have the capacity to test this myself right now.