### PR TITLE
Undefine NVRAM on vm destruction

### DIFF
--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -90,9 +90,9 @@ module Fog
           volumes.first.path if volumes and volumes.first
         end
 
-        def destroy(options={ :destroy_volumes => false, :flags => 0 })
+        def destroy(options={ :destroy_volumes => false, :flags => ::Libvirt::Domain::UNDEFINE_NVRAM })
           poweroff unless stopped?
-          if options.fetch(:flags, 0).zero?
+          if options.fetch(:flags, ::Libvirt::Domain::UNDEFINE_NVRAM).zero?
             service.vm_action(uuid, :undefine)
           else
             service.vm_action(uuid, :undefine, options[:flags])


### PR DESCRIPTION
VMs with UEFI store UEFI variables in OVMF files. This flag tells Libvirt to undefine it, if it exists. This was introduced in libvirt 1.2.6, which can be found on very old EL7 systems, but those are no longer supported. EL 7.9 (only supported EL7 version) ships libvirt 4.5.

This replaces https://github.com/fog/fog-libvirt/pull/107