### PR TITLE
Fix possible nil volumes for libvirt

### DIFF
--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -147,7 +147,7 @@ module Fog
 
         def volumes
           # lazy loading of volumes
-          @volumes ||= (@volumes_path || []).map{|path| service.volumes.all(:path => path).first }
+          @volumes ||= (@volumes_path || []).map{ |path| service.volumes.all(:path => path).first }.compact
         end
 
         def private_ip_address


### PR DESCRIPTION
@ekohl, whist I was trying to run Foreman tests on Ruby 2.7/3.0 via GA I've noticed that sometimes `volumes` can be `[nil]`. It's probably an issue with the setup, but the fix still makes this safer.