### PR TITLE
Implement EFI host creation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,3 +21,7 @@ SignalException:
 
 Metrics/ClassLength:
   Enabled: false
+
+Metrics/BlockLength:
+  Exclude:
+    - tests/**/*.rb


### PR DESCRIPTION
This implements EFI host creation by specifying the os_firmware attribute to be efi. It's also possible to set the os_loader attribute to secure (for UEFI secure boot) or stateless (for AMD SEV). Both secure and stateless imply the os_firmware to be efi.

It includes #132 because the secure boot loader creates NVRAM and otherwise you wouldn't be able to delete those machines.

Only minimal testing on Fedora 38 has been done, but I can create VMs and have them boot up.

Fixes #128