### PR TITLE
feat: replaced unsupported ide with q35 machine type with scsi cdrom …

### DIFF
--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -357,9 +357,9 @@ module Fog
                   xml.disk(:type => "file", :device => "cdrom") do
                     xml.driver(:name => "qemu", :type => "raw")
                     xml.source(:file => "#{iso_dir}/#{iso_file}")
-                    xml.target(:dev => "hdc", :bus => "ide")
+                    xml.target(:dev => "sda", :bus => "scsi")
                     xml.readonly
-                    xml.address(:type => "drive", :controller => 0, :bus => 1, :unit => 0)
+                    xml.address(:type => "drive", :controller => 0, :bus => 0, :unit => 0)
                   end
                 end
 


### PR DESCRIPTION
Implements SCSI as cdrom driver instead of IDE because it is incompatible with machine type q35 as introduced in #127 . It should resolve the issue raised in #136 .
