### PR TITLE
Correct the VNC password attribute

### DIFF
--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -408,7 +408,7 @@ module Fog
                     graphics.autoport = "yes"
                   end
                   graphics.listen = display[:listen] unless display[:listen].empty?
-                  graphics.password = display[:password] unless display[:password].empty?
+                  graphics.passwd = display[:password] unless display[:password].empty?
 
                   xml.video do
                     xml.model(:type => "cirrus", :vram => 9216, :heads => 1)


### PR DESCRIPTION
In the refactor to the XML builder a subtle bug was introduced which caused the password not to be set. This uses the correct attribute.

Came up in https://community.theforeman.org/t/error-creating-libvirt-based-guest-after-upgrading-to-3-10/38295. I'm asking the reporter to test this patch.

Fixes: 6db6f8089418 ("Replace server XML with Nokogiri::XML::Builder")