### PR TITLE
Pin ruby-libvirt to < 0.8.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,7 @@ group :development, :test do
   gem "octokit", :require => false
 end
 
+# 0.8.3 breaks our tests
+gem "ruby-libvirt", ">= 0.7.0", "< 0.8.3"
+
 gemspec


### PR DESCRIPTION
This version breaks our tests. The code itself continues working, so it pins in Gemfile instead of gemspec.

While the change for the test suite is ready, this allows us to do a much needed bugfix release first.