### PR TITLE
Correctly pass UNDEFINE_NVRAM when flags isn't pased

### DIFF
--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -92,10 +92,11 @@ module Fog
 
         def destroy(options={ :destroy_volumes => false, :flags => ::Libvirt::Domain::UNDEFINE_NVRAM })
           poweroff unless stopped?
-          if options.fetch(:flags, ::Libvirt::Domain::UNDEFINE_NVRAM).zero?
+          flags = options.fetch(:flags, ::Libvirt::Domain::UNDEFINE_NVRAM)
+          if flags.zero?
             service.vm_action(uuid, :undefine)
           else
-            service.vm_action(uuid, :undefine, options[:flags])
+            service.vm_action(uuid, :undefine, flags)
           end
           volumes.each { |vol| vol.destroy } if options[:destroy_volumes]
           true


### PR DESCRIPTION
If `destroy()` is called with options that doesn't contain a `flags` value then it should still default to `UNDEFINE_NVRAM`. That wasn't happening.

Fixes: 21d1bf827c03 ("Undefine NVRAM on vm destruction")

Fixes #142