### PR TITLE
Filter out UNDEFINE_NVRAM for test:///default

### DIFF
--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -97,6 +97,10 @@ module Fog
           if flags.zero?
             service.vm_action(uuid, :undefine)
           else
+            # the test driver doesn't support UNDEFINE_NVRAM
+            if service.uri.driver == 'test'
+              flags ^= ::Libvirt::Domain::UNDEFINE_NVRAM
+            end
             service.vm_action(uuid, :undefine, flags)
           end
           volumes.each { |vol| vol.destroy } if options[:destroy_volumes]

--- a/tests/libvirt/models/compute/server_tests.rb
+++ b/tests/libvirt/models/compute/server_tests.rb
@@ -13,7 +13,7 @@ Shindo.tests('Fog::Compute[:libvirt] | server model', ['libvirt']) do
       %w{ start stop destroy reboot suspend }.each do |action|
         test(action) { server.respond_to? action }
       end
-      %w{ start reboot suspend stop destroy}.each do |action|
+      %w{ start reboot suspend stop }.each do |action|
         test("#{action} returns successfully") {
           begin
             server.send(action.to_sym)
@@ -60,6 +60,11 @@ Shindo.tests('Fog::Compute[:libvirt] | server model', ['libvirt']) do
         end
       end
     end
+
+    test('can destroy') do
+      servers.create(:name => Fog::Mock.random_letters(8)).destroy
+    end
+
     test('be a kind of Fog::Libvirt::Compute::Server') { server.kind_of? Fog::Libvirt::Compute::Server }
     tests("serializes to xml") do
       test("with memory") { server.to_xml.match?(%r{<memory>\d+</memory>}) }


### PR DESCRIPTION
The test driver doesn't support UNDEFINE_NVRAM and I couldn't find a way to probe for the capability. This hacks around it by looking at the service uri and filters out the flag.

It also adds an explicit test since previously the exception was swallowed. A new server is created to avoid interference with other tests.