### PR TITLE
Filter out UNDEFINE_NVRAM for test:///default

### DIFF
--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -96,6 +96,10 @@ module Fog
           if flags.zero?
             service.vm_action(uuid, :undefine)
           else
+            # the test driver doesn't support UNDEFINE_NVRAM
+            if service.uri.driver == 'test'
+              flags ^= ::Libvirt::Domain::UNDEFINE_NVRAM
+            end
             service.vm_action(uuid, :undefine, flags)
           end
           volumes.each { |vol| vol.destroy } if options[:destroy_volumes]


### PR DESCRIPTION
The test driver doesn't support UNDEFINE_NVRAM and I couldn't find a way to probe for the capability. This hacks around it by looking at the service uri and filters out the flag.

It also adds an explicit test since previously the exception was swallowed. A new server is created to avoid interference with other tests.

(cherry picked from commit 14ac85efb35e0a1e1a2542b082d948a2616ea39b)