### PR TITLE
Allow setting cpu mode again

### DIFF
--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -307,7 +307,7 @@ module Fog
                   end
                 else
                   xml.cpu(
-                    :mode => cpu.dig(:model, :name) || "host-passthrough",
+                    :mode => cpu.fetch(:mode, "host-passthrough"),
                     :check => cpu.fetch(:check, "none"),
                     :migratable => cpu.fetch(:migratable, "on")
                   )


### PR DESCRIPTION
The value for `cpu.dig(:model, :name)` is always `nil` since that's the condition in the `if` statement. It was intended to still respect the cpu mode option passed in.

Fixes: 7a3a46b48fe7 ("Prefer CPU host pass through over explicit models")