### PR TITLE
Run RuboCop CI step on Ruby 3.3

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -9,7 +9,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.0
+          ruby-version: 3.3
       - name: rubocop
         uses: reviewdog/action-rubocop@v2
         with:


### PR DESCRIPTION
The gemset is becoming uninstallable on Ruby 2.7 and at least requires Ruby 3.1. Version 3.3 is picked since it's the latest version supported in the CI matrix.