### PR TITLE
Force test:// URI to be used in mocked connections

### DIFF
--- a/lib/fog/libvirt/compute.rb
+++ b/lib/fog/libvirt/compute.rb
@@ -117,6 +117,12 @@ module Fog
 
       class Mock
         include Shared
+
+        def enhance_uri(uri)
+          uri = 'test:///default' unless ::URI.parse(uri).scheme == 'test'
+
+          super(uri)
+        end
       end
     end
   end


### PR DESCRIPTION
Prior to 801ce47ed9fe1295f2753eafabdf4e97021767f7 any URL could be used when mocking and it had preconfigured responses, but this regressed and could cause real system connections to go through.

This forces the URL to use the test:// scheme which still allows the use of test:///path/to/host/definitions as documented.

Fixes: 801ce47ed9fe ("Use test:///default in tests")
Reference: https://libvirt.org/uri.html#test-test-uris