### PR TITLE
Drop unused json, fog-json and fog-xml dependencies & add nokogiri

### DIFF
--- a/fog-libvirt.gemspec
+++ b/fog-libvirt.gemspec
@@ -25,9 +25,8 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.7'
 
   s.add_dependency("fog-core", ">= 1.27.4")
-  s.add_dependency("fog-json")
-  s.add_dependency("fog-xml", "~> 0.1.1")
-  s.add_dependency("json")
+  # 1.11 introduced support for Ruby 2.7 as precompiled gem
+  s.add_dependency("nokogiri", "~> 1.11")
   s.add_dependency('ruby-libvirt','>= 0.7.0')
 
   s.add_development_dependency("minitest", "~> 5.0")

--- a/lib/fog/libvirt.rb
+++ b/lib/fog/libvirt.rb
@@ -1,6 +1,4 @@
 require 'fog/core'
-require 'fog/xml'
-require 'fog/json'
 require 'libvirt'
 
 require File.expand_path('../libvirt/version', __FILE__)


### PR DESCRIPTION
This gem doesn't use JSON at all and uses nokogiri directly instead of fog-xml. This removes the dependencies and instead adds nokogiri directly.

fog-xml has nokogiri 1.5.11 as the lower bound. This is updated to 1.11 because that version introduced native gems for 2.7. It's also already 3 years old so it should be usable for everyone. There were plenty of CVEs in older versions.