### PR TITLE
Remove unused erb and ostruct requires from util

### DIFF
--- a/lib/fog/libvirt/models/compute/util/util.rb
+++ b/lib/fog/libvirt/models/compute/util/util.rb
@@ -1,5 +1,4 @@
 require 'nokogiri'
-require 'erb'
 require 'securerandom'
 
 module Fog

--- a/lib/fog/libvirt/models/compute/util/util.rb
+++ b/lib/fog/libvirt/models/compute/util/util.rb
@@ -1,6 +1,5 @@
 require 'nokogiri'
 require 'erb'
-require 'ostruct'
 require 'securerandom'
 
 module Fog


### PR DESCRIPTION
These aren't used anymore and at least erb is causing problems on Ruby 3.3 with Archlinux.

Closes #159