### PR TITLE
Update default video device to vga

### DIFF
--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -558,7 +558,7 @@ module Fog
             :cpu                    => {},
             :hugepages              => false,
             :guest_agent            => true,
-            :video                  => {:type => "cirrus", :vram => 9216, :heads => 1},
+            :video                  => {:type => "vga", :heads => 1},
             :virtio_rng             => {},
             :firmware_features      => { "secure-boot" => "no" },
           }


### PR DESCRIPTION
For over a decade the cirrus driver has been considered outdated and the vga driver is preferred. A common alternative is qxl, but that implies the use of spice which isn't shipped in at least RHEL.

It leaves out the vram and relies on libvirt to set a sane default.

At this moment I haven't tested it, but it came out of https://github.com/fog/fog-libvirt/pull/71.

Link: https://www.kraxel.org/blog/2014/10/qemu-using-cirrus-considered-harmful/