### PR TITLE
Deal with missing volume_type

### DIFF
--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -368,7 +368,9 @@ module Fog
                   else
                     is_block = volume.path.start_with?("/dev/")
                     xml.disk(:type => is_block ? "block" : "file", :device => "disk") do
-                      xml.driver(:name => "qemu", :type => volume.format_type)
+                      driver = xml.driver(:name => "qemu")
+                      driver[:type] = volume.format_type if volume.format_type
+
                       if is_block
                         xml.source(:dev => volume.path)
                       else

--- a/lib/fog/libvirt/models/compute/volume.rb
+++ b/lib/fog/libvirt/models/compute/volume.rb
@@ -91,7 +91,7 @@ module Fog
               xml.capacity(capacity_size, :unit => capacity_unit)
 
               xml.target do
-                xml.format(:type => format_type)
+                xml.format(:type => format_type) if format_type
                 xml_permissions(xml)
               end
 


### PR DESCRIPTION
LVM volumes do not have a volume type and after a reload the value is set to nil. 0277e9b42589836134763dd182fe6025bf8349df introduced that reload after saving. The mock driver doesn't properly show this behavior, which is why it was missed. A test is added to simulate the real world behavior.

Fixes: 0277e9b42589836134763dd182fe6025bf8349df ("Correctly load volumes after creation and cloning")
Link: https://libvirt.org/formatstorage.html#storage-volume-target-elements
Link: https://libvirt.org/storage.html#valid-logical-volume-format-types

Fixes #169