### PR TITLE
fix lost default volume_type after creating LVM volume

### DIFF
--- a/lib/fog/libvirt/models/compute/volume.rb
+++ b/lib/fog/libvirt/models/compute/volume.rb
@@ -53,6 +53,15 @@ module Fog
           service.volume_action key, :wipe
         end
 
+        def reload
+          super
+
+          # Restore lost defaults
+          self.format_type ||= defaults[:format_type]
+
+          self
+        end
+
         # Clones this volume to the name provided
         def clone(name)
           new_volume      = self.dup


### PR DESCRIPTION
fixes #169

See https://github.com/fog/fog-libvirt/pull/172#issuecomment-2890855193 for a reproducer of the bug