### PR TITLE
Change default video card to virtio. 

### DIFF
--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -558,7 +558,7 @@ module Fog
             :cpu                    => {},
             :hugepages              => false,
             :guest_agent            => true,
-            :video                  => {:type => "vga", :heads => 1},
+            :video                  => {:type => "virtio", :heads => 1},
             :virtio_rng             => {},
             :firmware_features      => { "secure-boot" => "no" },
           }


### PR DESCRIPTION
Change default video card to virtio. This is the optimal video card to use with Linux based virtual machines. It is also the default video card use by other virtualization platforms such as OpenStack.

Signed-off-by: Jerone Young <jyoung@redhat.com>