### PR TITLE
Switch from genisoimage to xorriso

### DIFF
--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -260,7 +260,7 @@ module Fog
           File.write(user_data_path, user_data)
 
           isofile = Tempfile.new(['init', '.iso']).path
-          unless system("xorrisofs -output #{isofile} -volid cidata -joliet -rock #{user_data_path} #{meta_data_path}")
+          unless system('xorrisofs', '-output', isofile, '-volid', 'cidata', '-joliet', '-rock', user_data_path, meta_data_path)
             raise Fog::Errors::Error.new("Couldn't generate cloud-init iso disk with xorrisofs.")
           end
           blk.call(isofile)

--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -260,8 +260,8 @@ module Fog
           File.write(user_data_path, user_data)
 
           isofile = Tempfile.new(['init', '.iso']).path
-          unless system("genisoimage -output #{isofile} -volid cidata -joliet -rock #{user_data_path} #{meta_data_path}")
-            raise Fog::Errors::Error.new("Couldn't generate cloud-init iso disk with genisoimage.")
+          unless system("xorrisofs -output #{isofile} -volid cidata -joliet -rock #{user_data_path} #{meta_data_path}")
+            raise Fog::Errors::Error.new("Couldn't generate cloud-init iso disk with xorrisofs.")
           end
           blk.call(isofile)
         end

--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -254,11 +254,13 @@ module Fog
         end
 
         def generate_config_iso_in_dir(dir_path, user_data, &blk)
-          FileUtils.touch(File.join(dir_path, "meta-data"))
-          File.open(File.join(dir_path, 'user-data'), 'w') { |f| f.write user_data }
+          meta_data_path = File.join(dir_path, 'meta-data')
+          FileUtils.touch(meta_data_path)
+          user_data_path = File.join(dir_path, 'user-data')
+          File.write(user_data_path, user_data)
 
           isofile = Tempfile.new(['init', '.iso']).path
-          unless system("genisoimage -output #{isofile} -volid cidata -joliet -rock #{File.join(dir_path, 'user-data')} #{File.join(dir_path, 'meta-data')}")
+          unless system("genisoimage -output #{isofile} -volid cidata -joliet -rock #{user_data_path} #{meta_data_path}")
             raise Fog::Errors::Error.new("Couldn't generate cloud-init iso disk with genisoimage.")
           end
           blk.call(isofile)

--- a/minitests/server/user_data_iso_test.rb
+++ b/minitests/server/user_data_iso_test.rb
@@ -26,7 +26,7 @@ class UserDataIsoTest < Minitest::Test
 
   def test_iso_is_generated
     in_a_temp_dir do |d|
-      @server.expects(:system).with(regexp_matches(/^xorrisofs/)).returns(true)
+      @server.expects(:system).with { |command, *_args| command == 'xorrisofs' }.returns(true)
       @server.generate_config_iso_in_dir(d, @test_data) {|iso| }
     end
   end

--- a/minitests/server/user_data_iso_test.rb
+++ b/minitests/server/user_data_iso_test.rb
@@ -26,7 +26,7 @@ class UserDataIsoTest < Minitest::Test
 
   def test_iso_is_generated
     in_a_temp_dir do |d|
-      @server.expects(:system).with(regexp_matches(/^genisoimage/)).returns(true)
+      @server.expects(:system).with(regexp_matches(/^xorrisofs/)).returns(true)
       @server.generate_config_iso_in_dir(d, @test_data) {|iso| }
     end
   end


### PR DESCRIPTION
The genisoimage package is no longer available in EL10 because it was long unmaintained. The xorrisofs command is a drop in replacement.

Also does some further clean ups.

Fixes #181