### PR TITLE
fix: handle nil network name for bridge/direct interfaces

### DIFF
--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -478,7 +478,11 @@ module Fog
         # if the server has multiple network interface
         def addresses(service_arg=service, options={})
           ip_address = nil
-          if (nic = self.nics&.first)
+          # Pick the first nic that actually has a network. Bridge/direct
+          # interfaces carry a nil network name, which can't be looked up and
+          # never has a libvirt-managed lease, so skip them in favour of a nic
+          # that can resolve to an address.
+          if (nic = self.nics&.find { |n| n.network })
             net = service.networks.all(:name => nic.network).first
             # Assume the lease expiring last is the current IP address
             ip_address = net&.dhcp_leases(nic.mac)&.max_by { |lse| lse["expirytime"] }&.dig("ipaddr")

--- a/lib/fog/libvirt/requests/compute/list_networks.rb
+++ b/lib/fog/libvirt/requests/compute/list_networks.rb
@@ -9,7 +9,7 @@ module Fog
               data << network_to_attributes(client.lookup_network_by_name(network_name))
             end
           else
-            data = [network_to_attributes(get_network_by_filter(filter))]
+            data = [network_to_attributes(get_network_by_filter(filter))].compact
           end
           data
         end
@@ -21,6 +21,8 @@ module Fog
             when :uuid
               client.lookup_network_by_uuid(filter[:uuid])
             when :name
+              return nil if filter[:name].nil?
+
               client.lookup_network_by_name(filter[:name])
           end
         end

--- a/minitests/server/nil_network_address_test.rb
+++ b/minitests/server/nil_network_address_test.rb
@@ -1,0 +1,40 @@
+require 'test_helper'
+
+# Bridge and direct interfaces have a nil network name. #addresses used to
+# pass that nil straight into a network lookup, which raised. It should instead
+# skip network-less nics and resolve an address from a nic that has one.
+class NilNetworkAddressTest < Minitest::Test
+  def setup
+    @compute = Fog::Compute[:libvirt]
+    @server = @compute.servers.new(:name => "test")
+  end
+
+  def test_returns_nil_without_raising_when_only_nic_has_no_network
+    bridge_nic = stub(:network => nil, :mac => "52:54:00:aa:bb:cc")
+    @server.stubs(:nics).returns([bridge_nic])
+    # No network is ever looked up, so the connection is never touched.
+    @server.service.expects(:networks).never
+
+    result = @server.send(:addresses)
+
+    assert_nil result[:public].first
+    assert_nil result[:private].first
+  end
+
+  def test_skips_network_less_nic_and_resolves_address_from_next
+    bridge_nic = stub(:network => nil, :mac => "52:54:00:aa:bb:cc")
+    nat_nic = stub(:network => "default", :mac => "52:54:00:01:02:03")
+    @server.stubs(:nics).returns([bridge_nic, nat_nic])
+
+    net = stub(:name => "default")
+    net.stubs(:dhcp_leases).with("52:54:00:01:02:03").returns([{ "expirytime" => 1000, "ipaddr" => "192.168.122.10" }])
+    networks = stub
+    networks.stubs(:all).with(:name => "default").returns([net])
+    @server.service.stubs(:networks).returns(networks)
+
+    result = @server.send(:addresses)
+
+    assert_equal "192.168.122.10", result[:public].first
+    assert_equal "192.168.122.10", result[:private].first
+  end
+end


### PR DESCRIPTION
## Problem

When a VM has a bridge or macvtap interface (e.g. from a Vagrant `public_network` with `:dev`), libvirt represents it without a source network attribute, so the nic's network name is `nil`. `addresses()` took `nics.first` unconditionally and passed that `nil` name down to `lookup_network_by_name(nil)`, raising:

```
TypeError: no implicit conversion of nil into String
```

This crashed `vagrant-libvirt` state checks on any VM with a bridge NIC.

## Fix

Primary fix is in `addresses()`: select the first nic that actually has a network instead of blindly taking the first nic. Bridge/direct interfaces have no network name and never carry a libvirt-managed lease, so skipping them both avoids the nil lookup and gives multi-nic VMs a better chance of resolving a real address.

As defense in depth, `get_network_by_filter` still returns `nil` early when the name filter is `nil`, and `list_networks` compacts the result so `Fog::Collection#load` never receives a nil entry. This keeps `lookup_network_by_name(nil)` from raising for any other caller. Happy to drop this layer if you'd rather keep the surface minimal.

## Tests

Added minitest coverage for `addresses()`:

- A bridge-only VM (single nic, nil network) returns no address and never performs a network lookup.
- A mixed VM (bridge nic first, NAT nic second) resolves the address from the networked nic.

Fixes `vagrant-libvirt` state checks crashing on VMs with bridge NICs.
