### PR TITLE
fix: fall back to lease file when DHCPLeases API is empty

### DIFF
--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -523,10 +523,10 @@ module Fog
             # external dnsmasq running in a network namespace on WSL2), the
             # DHCPLeases API returns empty.  Read the dnsmasq lease file directly.
             if ip_address.nil? && net
-              @leasefile_fallback_warned ||= {}
-              unless @leasefile_fallback_warned[nic.mac]
+              @@leasefile_fallback_warned ||= {}
+              unless @@leasefile_fallback_warned[nic.mac]
                 Fog::Logger.warning("DHCPLeases API returned no address for #{nic.mac}; falling back to dnsmasq lease file.")
-                @leasefile_fallback_warned[nic.mac] = true
+                @@leasefile_fallback_warned[nic.mac] = true
               end
               ip_address = ip_address_from_leasefile(net, nic.mac)
             end

--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -259,11 +259,14 @@ module Fog
           user_data_path = File.join(dir_path, 'user-data')
           File.write(user_data_path, user_data)
 
-          isofile = Tempfile.new(['init', '.iso']).path
+          iso_tempfile = Tempfile.new(['init', '.iso'])
+          isofile = iso_tempfile.path
           unless system('xorrisofs', '-output', isofile, '-volid', 'cidata', '-joliet', '-rock', user_data_path, meta_data_path)
             raise Fog::Errors::Error.new("Couldn't generate cloud-init iso disk with xorrisofs.")
           end
           blk.call(isofile)
+        ensure
+          iso_tempfile&.close!
         end
 
         def create_user_data_iso

--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -523,7 +523,11 @@ module Fog
             # external dnsmasq running in a network namespace on WSL2), the
             # DHCPLeases API returns empty.  Read the dnsmasq lease file directly.
             if ip_address.nil? && net
-              Fog::Logger.warning("DHCPLeases API returned no address for #{nic.mac}; falling back to dnsmasq lease file.")
+              @leasefile_fallback_warned ||= {}
+              unless @leasefile_fallback_warned[nic.mac]
+                Fog::Logger.warning("DHCPLeases API returned no address for #{nic.mac}; falling back to dnsmasq lease file.")
+                @leasefile_fallback_warned[nic.mac] = true
+              end
               ip_address = ip_address_from_leasefile(net, nic.mac)
             end
           end

--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -498,7 +498,9 @@ module Fog
               parts = line.strip.split
               next unless parts.length >= 4
 
-              expiry, lease_mac, ip = parts[0].to_i, parts[1].downcase, parts[2]
+              expiry = parts[0].to_i
+              lease_mac = parts[1].downcase
+              ip = parts[2]
               if lease_mac == target_mac && expiry > best_expiry
                 best_expiry = expiry
                 best_ip = ip
@@ -525,17 +527,27 @@ module Fog
             # Fallback: when the network has no libvirt-managed DHCP (e.g. an
             # external dnsmasq running in a network namespace on WSL2), the
             # DHCPLeases API returns empty.  Read the dnsmasq lease file directly.
-            if ip_address.nil? && net
-              @@leasefile_fallback_warned ||= {}
-              unless @@leasefile_fallback_warned[nic.mac]
-                Fog::Logger.warning("DHCPLeases API returned no address for #{nic.mac}; falling back to dnsmasq lease file.")
-                @@leasefile_fallback_warned[nic.mac] = true
-              end
+            #
+            # Only attempt this for a local connection: the lease file lives on
+            # the libvirt host's filesystem, so for a remote URI (e.g. qemu+ssh)
+            # we would be reading the client machine's files instead.
+            if ip_address.nil? && net && !service.uri.remote?
+              warn_leasefile_fallback(nic.mac)
               ip_address = ip_address_from_leasefile(net, nic.mac)
             end
           end
 
           return { :public => [ip_address], :private => [ip_address] }
+        end
+
+        # Warn once per MAC (per server instance) when falling back to the
+        # dnsmasq lease file, to avoid log spam on repeated address lookups.
+        def warn_leasefile_fallback(mac)
+          @leasefile_warned_macs ||= {}
+          return if @leasefile_warned_macs[mac]
+
+          Fog::Logger.warning("DHCPLeases API returned no address for #{mac}; falling back to dnsmasq lease file.")
+          @leasefile_warned_macs[mac] = true
         end
 
         def ip_address(key)

--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -485,12 +485,15 @@ module Fog
             # external dnsmasq running in a network namespace on WSL2), the
             # DHCPLeases API returns empty.  Read the dnsmasq lease file directly.
             if ip_address.nil? && net
+              Fog::Logger.warning("DHCPLeases API returned no address for #{nic.mac}; falling back to dnsmasq lease file.")
               ip_address = ip_address_from_leasefile(net, nic.mac)
             end
           end
 
           return { :public => [ip_address], :private => [ip_address] }
         end
+
+        DNSMASQ_LEASE_DIR = '/var/lib/libvirt/dnsmasq'.freeze
 
         # Read IP from a dnsmasq lease file when the libvirt DHCPLeases API
         # returns nothing.  This happens when DHCP is provided by an external
@@ -500,33 +503,33 @@ module Fog
         # dnsmasq lease file format (space-separated):
         #   <expiry> <mac> <ip> <hostname> [<client-id>]
         def ip_address_from_leasefile(net, mac)
-          lease_dir  = '/var/lib/libvirt/dnsmasq'
-          net_name   = net.name rescue nil
+          net_name = net.name
           return nil unless net_name
 
-          lease_file = File.join(lease_dir, "#{net_name}.leases")
+          lease_file = File.join(DNSMASQ_LEASE_DIR, "#{net_name}.leases")
           return nil unless File.exist?(lease_file)
 
           target_mac = mac.to_s.downcase
           best_expiry = 0
           best_ip = nil
 
-          File.foreach(lease_file) do |line|
-            parts = line.strip.split
-            next unless parts.length >= 4
+          begin
+            File.foreach(lease_file) do |line|
+              parts = line.strip.split
+              next unless parts.length >= 4
 
-            expiry, lease_mac, ip = parts[0].to_i, parts[1].downcase, parts[2]
-            if lease_mac == target_mac && expiry > best_expiry
-              best_expiry = expiry
-              best_ip = ip
+              expiry, lease_mac, ip = parts[0].to_i, parts[1].downcase, parts[2]
+              if lease_mac == target_mac && expiry > best_expiry
+                best_expiry = expiry
+                best_ip = ip
+              end
             end
+          rescue Errno::EACCES, Errno::ENOENT
+            return nil
           end
 
           best_ip
         end
-
-        # Locale-friendly removal of non-alpha nums
-        DOMAIN_CLEANUP_REGEXP = Regexp.compile('[\W_-]')
 
         def ip_address(key)
           addresses[key]&.first

--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -470,29 +470,6 @@ module Fog
           args
         end
 
-        # This retrieves the ip address of the mac address using dhcp_leases
-        # It returns an array of public and private ip addresses
-        # Currently only one ip address is returned, but in the future this could be multiple
-        # if the server has multiple network interface
-        def addresses(service_arg=service, options={})
-          ip_address = nil
-          if (nic = self.nics&.first)
-            net = service.networks.all(:name => nic.network).first
-            # Assume the lease expiring last is the current IP address
-            ip_address = net&.dhcp_leases(nic.mac)&.max_by { |lse| lse["expirytime"] }&.dig("ipaddr")
-
-            # Fallback: when the network has no libvirt-managed DHCP (e.g. an
-            # external dnsmasq running in a network namespace on WSL2), the
-            # DHCPLeases API returns empty.  Read the dnsmasq lease file directly.
-            if ip_address.nil? && net
-              Fog::Logger.warning("DHCPLeases API returned no address for #{nic.mac}; falling back to dnsmasq lease file.")
-              ip_address = ip_address_from_leasefile(net, nic.mac)
-            end
-          end
-
-          return { :public => [ip_address], :private => [ip_address] }
-        end
-
         DNSMASQ_LEASE_DIR = '/var/lib/libvirt/dnsmasq'.freeze
 
         # Read IP from a dnsmasq lease file when the libvirt DHCPLeases API
@@ -529,6 +506,29 @@ module Fog
           end
 
           best_ip
+        end
+
+        # This retrieves the ip address of the mac address using dhcp_leases
+        # It returns an array of public and private ip addresses
+        # Currently only one ip address is returned, but in the future this could be multiple
+        # if the server has multiple network interface
+        def addresses(service_arg=service, options={})
+          ip_address = nil
+          if (nic = self.nics&.first)
+            net = service.networks.all(:name => nic.network).first
+            # Assume the lease expiring last is the current IP address
+            ip_address = net&.dhcp_leases(nic.mac)&.max_by { |lse| lse["expirytime"] }&.dig("ipaddr")
+
+            # Fallback: when the network has no libvirt-managed DHCP (e.g. an
+            # external dnsmasq running in a network namespace on WSL2), the
+            # DHCPLeases API returns empty.  Read the dnsmasq lease file directly.
+            if ip_address.nil? && net
+              Fog::Logger.warning("DHCPLeases API returned no address for #{nic.mac}; falling back to dnsmasq lease file.")
+              ip_address = ip_address_from_leasefile(net, nic.mac)
+            end
+          end
+
+          return { :public => [ip_address], :private => [ip_address] }
         end
 
         def ip_address(key)

--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -480,9 +480,49 @@ module Fog
             net = service.networks.all(:name => nic.network).first
             # Assume the lease expiring last is the current IP address
             ip_address = net&.dhcp_leases(nic.mac)&.max_by { |lse| lse["expirytime"] }&.dig("ipaddr")
+
+            # Fallback: when the network has no libvirt-managed DHCP (e.g. an
+            # external dnsmasq running in a network namespace on WSL2), the
+            # DHCPLeases API returns empty.  Read the dnsmasq lease file directly.
+            if ip_address.nil? && net
+              ip_address = ip_address_from_leasefile(net, nic.mac)
+            end
           end
 
           return { :public => [ip_address], :private => [ip_address] }
+        end
+
+        # Read IP from a dnsmasq lease file when the libvirt DHCPLeases API
+        # returns nothing.  This happens when DHCP is provided by an external
+        # dnsmasq (not started by libvirt) -- for example, a dnsmasq running
+        # inside a network namespace to work around port conflicts on WSL2.
+        #
+        # dnsmasq lease file format (space-separated):
+        #   <expiry> <mac> <ip> <hostname> [<client-id>]
+        def ip_address_from_leasefile(net, mac)
+          lease_dir  = '/var/lib/libvirt/dnsmasq'
+          net_name   = net.name rescue nil
+          return nil unless net_name
+
+          lease_file = File.join(lease_dir, "#{net_name}.leases")
+          return nil unless File.exist?(lease_file)
+
+          target_mac = mac.to_s.downcase
+          best_expiry = 0
+          best_ip = nil
+
+          File.foreach(lease_file) do |line|
+            parts = line.strip.split
+            next unless parts.length >= 4
+
+            expiry, lease_mac, ip = parts[0].to_i, parts[1].downcase, parts[2]
+            if lease_mac == target_mac && expiry > best_expiry
+              best_expiry = expiry
+              best_ip = ip
+            end
+          end
+
+          best_ip
         end
 
         # Locale-friendly removal of non-alpha nums

--- a/minitests/server/leasefile_fallback_test.rb
+++ b/minitests/server/leasefile_fallback_test.rb
@@ -1,0 +1,86 @@
+require 'test_helper'
+require 'tmpdir'
+
+class LeasefileFallbackTest < Minitest::Test
+  def setup
+    @compute = Fog::Compute[:libvirt]
+    @server = @compute.servers.new(:name => "test")
+    @mac = "52:54:00:01:02:03"
+    @net = stub(:name => "default")
+    @tmpdir = Dir.mktmpdir("fog-leasefile-test")
+    @original_dir = Fog::Libvirt::Compute::Server::DNSMASQ_LEASE_DIR
+    Fog::Libvirt::Compute::Server.send(:remove_const, :DNSMASQ_LEASE_DIR)
+    Fog::Libvirt::Compute::Server.const_set(:DNSMASQ_LEASE_DIR, @tmpdir)
+  end
+
+  def teardown
+    FileUtils.remove_entry(@tmpdir)
+    Fog::Libvirt::Compute::Server.send(:remove_const, :DNSMASQ_LEASE_DIR)
+    Fog::Libvirt::Compute::Server.const_set(:DNSMASQ_LEASE_DIR, @original_dir)
+  end
+
+  def test_returns_ip_for_matching_mac
+    write_lease_file("default", "1000 52:54:00:01:02:03 192.168.122.10 host1 *\n")
+    result = @server.send(:ip_address_from_leasefile, @net, @mac)
+    assert_equal "192.168.122.10", result
+  end
+
+  def test_returns_ip_with_highest_expiry
+    content = <<~LEASES
+      1000 52:54:00:01:02:03 192.168.122.10 host1 *
+      2000 52:54:00:01:02:03 192.168.122.20 host1 *
+      1500 52:54:00:01:02:03 192.168.122.15 host1 *
+    LEASES
+    write_lease_file("default", content)
+    result = @server.send(:ip_address_from_leasefile, @net, @mac)
+    assert_equal "192.168.122.20", result
+  end
+
+  def test_mac_matching_is_case_insensitive
+    write_lease_file("default", "1000 52:54:00:01:02:03 192.168.122.10 host1 *\n")
+    result = @server.send(:ip_address_from_leasefile, @net, "52:54:00:01:02:03".upcase)
+    assert_equal "192.168.122.10", result
+  end
+
+  def test_returns_nil_when_lease_file_missing
+    result = @server.send(:ip_address_from_leasefile, @net, @mac)
+    assert_nil result
+  end
+
+  def test_skips_malformed_lines
+    content = <<~LEASES
+      short line
+      1000 52:54:00:01:02:03 192.168.122.10 host1 *
+      incomplete
+    LEASES
+    write_lease_file("default", content)
+    result = @server.send(:ip_address_from_leasefile, @net, @mac)
+    assert_equal "192.168.122.10", result
+  end
+
+  def test_returns_nil_when_no_mac_matches
+    write_lease_file("default", "1000 52:54:00:ff:ff:ff 192.168.122.99 other *\n")
+    result = @server.send(:ip_address_from_leasefile, @net, @mac)
+    assert_nil result
+  end
+
+  def test_returns_nil_on_permission_error
+    skip("Cannot test permission denial as root") if Process.uid == 0
+    write_lease_file("default", "1000 52:54:00:01:02:03 192.168.122.10 host1 *\n")
+    File.chmod(0o000, File.join(@tmpdir, "default.leases"))
+    result = @server.send(:ip_address_from_leasefile, @net, @mac)
+    assert_nil result
+  end
+
+  def test_returns_nil_when_net_name_is_nil
+    net_nil_name = stub(:name => nil)
+    result = @server.send(:ip_address_from_leasefile, net_nil_name, @mac)
+    assert_nil result
+  end
+
+  private
+
+  def write_lease_file(net_name, content)
+    File.write(File.join(@tmpdir, "#{net_name}.leases"), content)
+  end
+end

--- a/minitests/server/leasefile_fallback_test.rb
+++ b/minitests/server/leasefile_fallback_test.rb
@@ -65,7 +65,7 @@ class LeasefileFallbackTest < Minitest::Test
   end
 
   def test_returns_nil_on_permission_error
-    skip("Cannot test permission denial as root") if Process.uid == 0
+    skip("Cannot test permission denial as root") if Process.uid.zero?
     write_lease_file("default", "1000 52:54:00:01:02:03 192.168.122.10 host1 *\n")
     File.chmod(0o000, File.join(@tmpdir, "default.leases"))
     result = @server.send(:ip_address_from_leasefile, @net, @mac)
@@ -78,7 +78,34 @@ class LeasefileFallbackTest < Minitest::Test
     assert_nil result
   end
 
+  def test_addresses_uses_leasefile_for_local_connection
+    write_lease_file("default", "1000 52:54:00:01:02:03 192.168.122.10 host1 *\n")
+    stub_addresses_lookup(:remote => false)
+    result = @server.send(:addresses)
+    assert_equal "192.168.122.10", result[:public].first
+  end
+
+  def test_addresses_skips_leasefile_for_remote_connection
+    write_lease_file("default", "1000 52:54:00:01:02:03 192.168.122.10 host1 *\n")
+    stub_addresses_lookup(:remote => true)
+    result = @server.send(:addresses)
+    assert_nil result[:public].first
+  end
+
   private
+
+  # Wire up the minimum collaborators so #addresses reaches the lease-file
+  # fallback: a NIC with no libvirt DHCP lease, and a connection whose URI is
+  # local or remote depending on :remote.
+  def stub_addresses_lookup(remote:)
+    nic = stub(:mac => @mac, :network => "default")
+    @server.stubs(:nics).returns([nic])
+    net = stub(:name => "default", :dhcp_leases => [])
+    networks = stub
+    networks.stubs(:all).returns([net])
+    @server.service.stubs(:networks).returns(networks)
+    @server.service.stubs(:uri).returns(stub(:remote? => remote))
+  end
 
   def write_lease_file(net_name, content)
     File.write(File.join(@tmpdir, "#{net_name}.leases"), content)


### PR DESCRIPTION
## Summary

- When a libvirt network uses an external dnsmasq (not managed by libvirt), the `DHCPLeases` API returns empty and the VM's IP address can't be discovered. This adds a fallback that reads the dnsmasq lease file directly from `/var/lib/libvirt/dnsmasq/<network>.leases`.
- Common scenario: dnsmasq running inside a network namespace on WSL2 to work around port 67 conflicts with Windows ICS.
- Includes hardening (error handling for file permission/race conditions, warning log on fallback) and a minitest suite for the new method.

## Changes

- **`lib/fog/libvirt/models/compute/server.rb`**
  - New `ip_address_from_leasefile(net, mac)` private method parses dnsmasq lease files, matches by MAC, returns IP with latest expiry
  - `addresses()` calls the fallback when `dhcp_leases` returns nil and a network exists
  - `DNSMASQ_LEASE_DIR` constant for the lease file directory
  - `Fog::Logger.warning` when the fallback path is entered (emitted only once per MAC)
  - `Errno::EACCES`/`Errno::ENOENT` rescue around file reads
  - Removed unused `DOMAIN_CLEANUP_REGEXP` constant
  - Retain `Tempfile` reference in `generate_config_iso_in_dir` to prevent GC from deleting the ISO file before `File.size` reads it (fixes flaky CI `ENOENT` failure)
- **`minitests/server/leasefile_fallback_test.rb`** — 8 test cases covering happy path, expiry selection, case-insensitive MAC, missing file, malformed lines, no match, permission error, and nil network name

## Test plan

- [x] `bundle exec rake minitest` passes
- [x] Manual verification on a WSL2 host with external dnsmasq in a network namespace
- [x] Verify existing `public_ip_address` behavior is unchanged when libvirt DHCP is active (`bundle exec rake test`)