### PR TITLE
fix: retain Tempfile reference to prevent cloud-init ISO GC race

### DIFF
--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -259,11 +259,14 @@ module Fog
           user_data_path = File.join(dir_path, 'user-data')
           File.write(user_data_path, user_data)
 
-          isofile = Tempfile.new(['init', '.iso']).path
+          iso_tempfile = Tempfile.new(['init', '.iso'])
+          isofile = iso_tempfile.path
           unless system('xorrisofs', '-output', isofile, '-volid', 'cidata', '-joliet', '-rock', user_data_path, meta_data_path)
             raise Fog::Errors::Error.new("Couldn't generate cloud-init iso disk with xorrisofs.")
           end
           blk.call(isofile)
+        ensure
+          iso_tempfile&.close!
         end
 
         def create_user_data_iso


### PR DESCRIPTION
## Summary

Splits an unrelated fix out of #190 at a maintainer's request.

`generate_config_iso` called `Tempfile.new(['init', '.iso']).path` and immediately discarded the `Tempfile` object. Once GC finalized it, the underlying ISO file was unlinked before downstream code could read it, causing flaky `ENOENT` failures.

This retains the `Tempfile` reference for the lifetime of the block and explicitly cleans it up in an `ensure`.

## Changes

- Keep the `Tempfile` object in `iso_tempfile`; derive `isofile` from `.path`.
- Add `ensure iso_tempfile&.close!` to unlink deterministically instead of relying on GC timing.

## Test plan

- [x] CI green (rubocop + test matrix 2.7–head)
- [x] cloud-init ISO generation no longer flakes on ENOENT