### PR TITLE
Explicitly set model='virtio-scsi' for SCSI controllers on Q35 guests

### DIFF
--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -395,7 +395,6 @@ module Fog
                     xml.address(:type => "drive", :controller => 0, :bus => 0, :unit => 0)
                   end
                 end
-                
                 if volumes.any? { |v| v.bus == 'scsi' }
                   xml.controller(:type => 'scsi', :index => '0', :model => 'virtio-scsi')
                 end

--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -395,6 +395,10 @@ module Fog
                     xml.address(:type => "drive", :controller => 0, :bus => 0, :unit => 0)
                   end
                 end
+                
+                if volumes.any? { |v| v.bus == 'scsi' }
+                  xml.controller(:type => 'scsi', :index => '0', :model => 'virtio-scsi')
+                end
 
                 nics.each do |nic|
                   xml.interface(:type => nic.type) do

--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -395,7 +395,9 @@ module Fog
                     xml.address(:type => "drive", :controller => 0, :bus => 0, :unit => 0)
                   end
                 end
-                if volumes.any? { |v| v.bus == 'scsi' }
+
+                if volumes.any? { |v| v.respond_to?(:bus) && v.bus == 'scsi' } || 
+                    (respond_to?(:disks) && disks.any? { |d| d.is_a?(Hash) && d[:bus] == 'scsi' })
                   xml.controller(:type => 'scsi', :index => '0', :model => 'virtio-scsi')
                 end
 


### PR DESCRIPTION
## Problem

When utilising image-based provisioning via Red Hat Satellite (specifically verified on Satellite 6.19.2 running fog-libvirt 0.14.0) onto a libvirt provider, cloud-init user-data fails to execute.

The breakdown occurs because Satellite/fog-libvirt targets a SCSI bus (bus='scsi') to attach the user-data ISO payload on modern Q35 machine types. However, because no explicit controller model is provided in the generated XML, libvirt defaults to a legacy controller emulation type (it was `lsilogic` on my system). 

Modern Red Hat Enterprise Linux (RHEL) minimal/cloud images don't load legacy storage drivers for `lsilogic`. As a result, the guest kernel cannot see the underlying storage controller, /dev/sda is never initialized inside the VM, and cloud-init fails to detect its datasource.

## Solution
This PR injects a conditional check inside the XML builder block within server.rb. If any attached volumes are configured to use a scsi bus, it programmatically forces libvirt to instantiate a modern virtio-scsi controller layout:

```
if volumes.any? { |v| v.bus == 'scsi' }
  xml.controller(:type => 'scsi', :index => '0', :model => 'virtio-scsi')end
```

This ensures out-of-the-box compatibility for RHEL cloud images.

## Development & Testing Notes

* **Disclaimer:** I am not natively a Ruby developer! After troubleshooting and isolating the root cause in the hypervisor XML configurations, I consulted a Large Language Model (LLM) to assist me in mapping the logic safely into the native Nokogiri syntax used by the gem's codebase. 

* **Validation:** This fix was live-patched directly into server.rb on a production Red Hat Satellite 6.19.2 server running fog-libvirt-0.14.0. Post-patch testing verified that newly provisioned VMs successfully attached the virtual media controller using virtio-scsi. The guest kernels immediately mapped the volume to /dev/sda, allowing cloud-init to fetch the metadata source and run the commands in user-data.