### PR TITLE
Implement support for tests using real libvirt with FOG_LIBVIRT_URI

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -47,8 +47,7 @@ end
 
 desc 'Run tests'
 task :test do
-  mock = ENV['FOG_MOCK'] || 'true'
-  sh("export FOG_MOCK=#{mock} && bundle exec shindont tests")
+  sh("bundle exec shindont tests")
 end
 
 desc 'Run mocked tests'
@@ -59,6 +58,11 @@ end
 desc 'Run live tests'
 task :live do
   sh("export FOG_MOCK=false && bundle exec shindont tests")
+end
+
+desc 'Run live libvirt qemu:///session tests'
+task :live_session do
+  sh("export FOG_LIBVIRT_URI=qemu:///session && bundle exec rake test minitest")
 end
 
 desc "Open an irb session preloaded with this library"

--- a/minitests/test_helper.rb
+++ b/minitests/test_helper.rb
@@ -17,7 +17,11 @@ FileUtils.rm_f Dir.glob 'test/tmp/*.tmp'
 
 require 'fog/libvirt'
 
-Fog.mock!
-Fog.credentials = {
-    :libvirt_uri => 'test:///default',
-}.merge(Fog.credentials)
+Fog.credentials[:libvirt_uri] = ENV.fetch("FOG_LIBVIRT_URI", "test:///default")
+
+def real_libvirt?
+  Fog.credentials[:libvirt_uri].start_with?("qemu")
+end
+
+enable_mocking = ENV.fetch("FOG_MOCK") { (!real_libvirt?).to_s }
+Fog.mock! unless ["false", "no", "0"].include?(enable_mocking)

--- a/tests/helper.rb
+++ b/tests/helper.rb
@@ -24,3 +24,4 @@ end
 
 Thread.current[:tags] ||= []
 Thread.current[:tags] << "-requires-mocks" unless Fog.mock?
+Thread.current[:tags] << (real_libvirt? ? "-requires-test-driver" : "-requires-real-libvirt")

--- a/tests/helper.rb
+++ b/tests/helper.rb
@@ -21,3 +21,6 @@ if Fog.mocking?
 else
   FOG_TESTING_TIMEOUT = Fog.timeout
 end
+
+Thread.current[:tags] ||= []
+Thread.current[:tags] << "-requires-mocks" unless Fog.mock?

--- a/tests/helpers/mock_helper.rb
+++ b/tests/helpers/mock_helper.rb
@@ -2,10 +2,11 @@
 #
 # FOG_MOCK=true fog
 
-if ENV["FOG_MOCK"] == "true"
-  Fog.mock!
+Fog.credentials[:libvirt_uri] = ENV.fetch("FOG_LIBVIRT_URI", "test:///default")
+
+def real_libvirt?
+  Fog.credentials[:libvirt_uri].start_with?("qemu")
 end
 
-Fog.credentials = {
-  :libvirt_uri => 'test:///default'
-}.merge(Fog.credentials)
+enable_mocking = ENV.fetch("FOG_MOCK") { (!real_libvirt?).to_s }
+Fog.mock! unless ["false", "no", "0"].include?(enable_mocking)

--- a/tests/helpers/mock_helper.rb
+++ b/tests/helpers/mock_helper.rb
@@ -6,9 +6,6 @@ if ENV["FOG_MOCK"] == "true"
   Fog.mock!
 end
 
-# if in mocked mode, fill in some fake credentials for us
-if Fog.mock?
-  Fog.credentials = {
-    :libvirt_uri => 'test:///default',
-  }.merge(Fog.credentials)
-end
+Fog.credentials = {
+  :libvirt_uri => 'test:///default'
+}.merge(Fog.credentials)

--- a/tests/libvirt/models/compute/network_tests.rb
+++ b/tests/libvirt/models/compute/network_tests.rb
@@ -1,7 +1,6 @@
 Shindo.tests('Fog::Compute[:libvirt] | network model', ['libvirt']) do
 
-  networks = Fog::Compute[:libvirt].networks
-  network = networks.first
+  network = Fog::Compute[:libvirt].networks.new(:name => "default", :uuid => "dd8fe884-6c02-601e-7551-cca97df1c5df", :bridge_name => "virbr0")
 
   tests('The network model should') do
     tests('have the action') do

--- a/tests/libvirt/models/compute/network_tests.rb
+++ b/tests/libvirt/models/compute/network_tests.rb
@@ -8,7 +8,7 @@ Shindo.tests('Fog::Compute[:libvirt] | network model', ['libvirt']) do
       test('reload') { network.respond_to? 'reload' }
       test('dhcp_leases') { network.respond_to? 'dhcp_leases' }
     end
-    tests('have a dhcp_leases action that') do
+    tests('have a dhcp_leases action that', 'requires-mocks') do
       test('returns an array') { network.dhcp_leases('aa:bb:cc:dd:ee:ff', 0).kind_of? Array }
     end
     tests('have attributes') do

--- a/tests/libvirt/models/compute/networks_tests.rb
+++ b/tests/libvirt/models/compute/networks_tests.rb
@@ -5,7 +5,7 @@ Shindo.tests('Fog::Compute[:libvirt] | networks collection', ['libvirt']) do
   tests('The networks collection') do
     test('should be a kind of Fog::Libvirt::Compute::Networks') { networks.kind_of? Fog::Libvirt::Compute::Networks }
     tests('should be able to reload itself').succeeds { networks.reload }
-    tests('should be able to get a model') do
+    tests('should be able to get a model', 'requires-test-driver') do
       tests('by instance id').succeeds { networks.get networks.first.uuid }
     end
   end

--- a/tests/libvirt/models/compute/nic_tests.rb
+++ b/tests/libvirt/models/compute/nic_tests.rb
@@ -1,6 +1,6 @@
 Shindo.tests('Fog::Compute[:libvirt] | nic model', ['libvirt']) do
 
-  server = Fog::Compute[:libvirt].servers.create(:name => Fog::Mock.random_letters(8))
+  server = Fog::Compute[:libvirt].servers.create(:name => "fog-nic-test-#{Fog::Mock.random_letters(8)}")
   nic = server.nics.first
 
   tests('The nic model should') do
@@ -28,5 +28,6 @@ Shindo.tests('Fog::Compute[:libvirt] | nic model', ['libvirt']) do
     end
     test('be a kind of Fog::Libvirt::Compute::Nic') { nic.kind_of? Fog::Libvirt::Compute::Nic }
   end
-
+ensure
+  server&.destroy(:destroy_volumes => true)
 end

--- a/tests/libvirt/models/compute/server_tests.rb
+++ b/tests/libvirt/models/compute/server_tests.rb
@@ -2,8 +2,8 @@ Shindo.tests('Fog::Compute[:libvirt] | server model', ['libvirt']) do
 
   servers = Fog::Compute[:libvirt].servers
   # Match the mac in dhcp_leases mock
-  nics = Fog.mock? ? [{ :type => 'network', :network => 'default', :mac => 'aa:bb:cc:dd:ee:ff' }] : nil
-  server = servers.create(:name => Fog::Mock.random_letters(8), :nics => nics)
+  nics = Fog.mock? ? [{ :type => 'network', :network => 'default', :mac => 'aa:bb:cc:dd:ee:ff' }] : []
+  server = servers.create(:name => "fog-server-test-#{Fog::Mock.random_letters(8)}", :nics => nics)
 
   tests('The server model should') do
     tests('have the action') do
@@ -66,7 +66,9 @@ Shindo.tests('Fog::Compute[:libvirt] | server model', ['libvirt']) do
     end
 
     test('can destroy') do
-      servers.create(:name => Fog::Mock.random_letters(8)).destroy
+      server_name = "fog-test-destroy-#{Fog::Mock.random_letters(8)}"
+      servers.create(:name => server_name).destroy(:destroy_volumes => true)
+      servers.all.none? { |server| server.name == server_name }
     end
 
     test('be a kind of Fog::Libvirt::Compute::Server') { server.kind_of? Fog::Libvirt::Compute::Server }
@@ -78,7 +80,7 @@ Shindo.tests('Fog::Compute[:libvirt] | server model', ['libvirt']) do
         xml.match?(/<disk type="file" device="disk">/) && xml.match?(%r{<source file="#{server.volumes.first.path}"/>})
       end
       test("with disk of type block") do
-        server = Fog::Libvirt::Compute::Server.new(
+        disk_server = Fog::Libvirt::Compute::Server.new(
           {
             :nics => [],
             :volumes => [
@@ -86,20 +88,20 @@ Shindo.tests('Fog::Compute[:libvirt] | server model', ['libvirt']) do
             ]
           }
         )
-        xml = server.to_xml
+        xml = disk_server.to_xml
         xml.match?(/<disk type="block" device="disk">/) && xml.match?(%r{<source dev="/dev/sda"/>})
       end
-      test("with q35 machine type on x86_64") { server.to_xml.match?(%r{<type arch="x86_64" machine="q35">hvm</type>}) }
+      test("with q35 machine type on x86_64") { server.to_xml.include?('<type arch="x86_64" machine="q35">') }
     end
     test("with efi firmware") do
-      server = Fog::Libvirt::Compute::Server.new(
+      efi_server = Fog::Libvirt::Compute::Server.new(
         {
           :firmware => "efi",
           :nics => [],
           :volumes => []
         }
       )
-      xml = server.to_xml
+      xml = efi_server.to_xml
 
       os_firmware = xml.include?('<os firmware="efi">')
       secure_boot = xml.include?('<feature name="secure-boot" enabled="no"/>')
@@ -108,7 +110,7 @@ Shindo.tests('Fog::Compute[:libvirt] | server model', ['libvirt']) do
       os_firmware && secure_boot && loader_attributes
     end
     test("with secure boot enabled") do
-      server = Fog::Libvirt::Compute::Server.new(
+      secure_server = Fog::Libvirt::Compute::Server.new(
         {
           :firmware => "efi",
           :firmware_features => {
@@ -120,7 +122,7 @@ Shindo.tests('Fog::Compute[:libvirt] | server model', ['libvirt']) do
           :volumes => []
         }
       )
-      xml = server.to_xml
+      xml = secure_server.to_xml
 
       os_firmware = xml.include?('<os firmware="efi">')
       secure_boot = xml.include?('<feature name="secure-boot" enabled="yes"/>')
@@ -135,7 +137,7 @@ Shindo.tests('Fog::Compute[:libvirt] | server model', ['libvirt']) do
         :persistent => true,
         :xml => <<~XML
           <pool type='logical'>
-            <name>lvm-pool</name>
+            <name>fog-test-lvm-pool</name>
             <source>
               <name>vg_storage01</name>
               <format type='lvm2'/>
@@ -146,7 +148,7 @@ Shindo.tests('Fog::Compute[:libvirt] | server model', ['libvirt']) do
           </pool>
         XML
       )
-      server = Fog::Compute[:libvirt].servers.new(
+      volume_server = Fog::Compute[:libvirt].servers.new(
         :nics => [],
         :volumes => [
           {
@@ -155,13 +157,18 @@ Shindo.tests('Fog::Compute[:libvirt] | server model', ['libvirt']) do
           }
         ]
       )
-      server.volumes.each do |volume|
+      volume_server.volumes.each do |volume|
         volume.save
         # mock driver doesn't simulate the real thing
         # LVM doesn't have a volume type
         volume.format_type = nil
       end
-      !server.save.nil?
+      !volume_server.save.nil?
+    ensure
+      volume_server&.destroy(:destroy_volumes => true)
+      pool&.destroy
     end
   end
+ensure
+  server&.destroy(:destroy_volumes => true)
 end

--- a/tests/libvirt/models/compute/server_tests.rb
+++ b/tests/libvirt/models/compute/server_tests.rb
@@ -24,7 +24,7 @@ Shindo.tests('Fog::Compute[:libvirt] | server model', ['libvirt']) do
         }
       end
     end
-    tests('have an ip_address action that') do
+    tests('have an ip_address action that', 'requires-mocks') do
       test('returns the latest IP address lease') { server.public_ip_address() == '1.2.5.6' }
     end
     tests('have attributes') do

--- a/tests/libvirt/models/compute/volume_tests.rb
+++ b/tests/libvirt/models/compute/volume_tests.rb
@@ -1,6 +1,6 @@
 Shindo.tests('Fog::Compute[:libvirt] | volume model', ['libvirt']) do
 
-  volume = Fog::Compute[:libvirt].volumes.create(:name => 'fog_test')
+  volume = Fog::Compute[:libvirt].volumes.create(:name => 'fog_test', :capacity => '1G')
 
   tests('The volume model should') do
     tests('have attributes') do
@@ -29,10 +29,12 @@ Shindo.tests('Fog::Compute[:libvirt] | volume model', ['libvirt']) do
 
   tests('Cloning volumes should') do
     test('respond to clone_volume') { volume.respond_to? :clone_volume }
-    new_vol = volume.clone_volume('new_vol')
+    new_vol = volume.clone_volume('fog-test-new_vol')
     # We'd like to test that the :name attr has changed, but it seems that's
     # not possible, so we can at least check the new_vol xml exists properly
     test('succeed') { volume.xml == new_vol.xml }
+  ensure
+    new_vol&.destroy
   end
 
   test('to_xml') do
@@ -42,7 +44,7 @@ Shindo.tests('Fog::Compute[:libvirt] | volume model', ['libvirt']) do
         <volume>
           <name>fog_test</name>
           <allocation unit="G">1</allocation>
-          <capacity unit="G">10</capacity>
+          <capacity unit="G">1</capacity>
           <target>
             <format type="raw"/>
             <permissions>
@@ -55,4 +57,6 @@ Shindo.tests('Fog::Compute[:libvirt] | volume model', ['libvirt']) do
       volume.to_xml == expected
     end
   end
+ensure
+  volume&.destroy
 end

--- a/tests/libvirt/models/compute/volumes_tests.rb
+++ b/tests/libvirt/models/compute/volumes_tests.rb
@@ -2,7 +2,7 @@ Shindo.tests('Fog::Compute[:libvirt] | volumes collection', ['libvirt']) do
 
   volumes = Fog::Compute[:libvirt].volumes
 
-  volumes.create(:name => 'test')
+  created_volume = volumes.create(:name => 'fog-test-volume')
 
   tests('The volumes collection') do
     test('should not be empty') { not volumes.empty? }
@@ -11,7 +11,8 @@ Shindo.tests('Fog::Compute[:libvirt] | volumes collection', ['libvirt']) do
     tests('should be able to get a model') do
       tests('by instance uuid').succeeds { volumes.get volumes.first.id }
     end
-    test('filtered should be empty') { volumes.all(:name => "does-not-exist").empty? }
+    test('filtered should be empty') { volumes.all(:name => "fog-test-volume-does-not-exist").empty? }
   end
-
+ensure
+  created_volume&.destroy
 end

--- a/tests/libvirt/requests/compute/create_domain_tests.rb
+++ b/tests/libvirt/requests/compute/create_domain_tests.rb
@@ -1,7 +1,9 @@
 Shindo.tests("Fog::Compute[:libvirt] | create_domain request", 'libvirt') do
 
   compute = Fog::Compute[:libvirt]
-  xml = compute.servers.new( :nics => [{:bridge => "br180"}]).to_xml
+
+  server = compute.servers.new(:name => "fog-test-create-server", :nics => [])
+  xml = server.to_xml
 
   tests("Create Domain") do
     response = compute.create_domain(xml)
@@ -17,5 +19,7 @@ Shindo.tests("Fog::Compute[:libvirt] | create_domain request", 'libvirt') do
       test("error should be a kind of Libvirt::Error") { e.kind_of?  Libvirt::Error}
     end
   end
-
+ensure
+  server_uuid = compute.servers.all(:name => server.name).first&.uuid
+  compute.servers.service.vm_action(server_uuid, :destroy) if server_uuid
 end

--- a/tests/libvirt/requests/compute/define_domain_tests.rb
+++ b/tests/libvirt/requests/compute/define_domain_tests.rb
@@ -1,11 +1,14 @@
 Shindo.tests("Fog::Compute[:libvirt] | define_domain request", 'libvirt') do
 
   compute = Fog::Compute[:libvirt]
-  xml = compute.servers.new().to_xml
+  server = compute.servers.new(:name => "fog-test-define-server", :nics => [])
+  xml = server.to_xml
 
   tests("Define Domain") do
     response = compute.define_domain(xml)
     test("should be a kind of Libvirt::Domain") { response.kind_of?  Libvirt::Domain}
   end
-
+ensure
+  server_uuid = compute.servers.all(:name => server.name).first&.uuid
+  compute.servers.service.vm_action(server_uuid, :undefine) if server_uuid
 end

--- a/tests/libvirt/requests/compute/dhcp_leases_tests.rb
+++ b/tests/libvirt/requests/compute/dhcp_leases_tests.rb
@@ -2,7 +2,7 @@ Shindo.tests("Fog::Compute[:libvirt] | dhcp_leases request", 'libvirt') do
 
   compute = Fog::Compute[:libvirt]
 
-  tests("DHCP leases response") do
+  tests("DHCP leases response", "requires-mocks") do
     response = compute.dhcp_leases("fbd4ac68-cbea-4f95-86ed-22953fd92384", "99:88:77:66:55:44", 0)
     test("should be an array") { response.kind_of? Array }
     test("should have one element") { response.length == 1 }

--- a/tests/libvirt/requests/compute/list_pools_tests.rb
+++ b/tests/libvirt/requests/compute/list_pools_tests.rb
@@ -41,7 +41,9 @@ Shindo.tests("Fog::Compute[:libvirt] | list_pools request", 'libvirt') do
   tests("Lists Pools") do
     response = compute.list_pools
     test("should be an array") { response.kind_of? Array }
-    test("should have two pools") { response.length == 1 }
+    tests("Test Driver", "requires-test-driver") do
+      test("should have a pool") { response.length == 1 }
+    end
   end
 
   tests("Handle Inactive Pools") do


### PR DESCRIPTION
Currently `rake live` fails with:
```
Fog::Compute[:libvirt] (libvirt)     
    fog-libvirt/tests/libvirt/compute_tests.rb
      Fog::Compute[:libvirt] (libvirt)
    Missing required arguments: libvirt_uri (ArgumentError)
```
First commit from this PR fixes that so `rake live` works.
2nd commit implements support for running tests against real libvirt by using `FOG_LIBVIRT_URI` env var.
All these are fully supported and work correctly:
```
$ rake
$ FOG_MOCK=true rake

$ FOG_MOCK=true FOG_LIBVIRT_URI=qemu:///session rake
$ FOG_MOCK=true FOG_LIBVIRT_URI=qemu:///system rake

$ FOG_MOCK=false rake
$ rake live

$ rake live_session
$ FOG_LIBVIRT_URI=qemu:///session rake
$ FOG_MOCK=false FOG_LIBVIRT_URI=qemu:///session rake
$ FOG_LIBVIRT_URI=qemu:///system rake
$ FOG_MOCK=false FOG_LIBVIRT_URI=qemu:///system rake
```
(something like `FOG_LIBVIRT_URI=qemu+ssh://host/system rake` should also work but I haven't tested)

I also fixed tests so they cleanup afterwards so there won't be test leftovers when running against real libvirt.
But note that with this feature tests shouldn't do something like `servers.all.each(&:destroy)` to not cause someone a bad day when run with real libvirt. If needed then such should only be run when using libvirt test driver only.
